### PR TITLE
Add `forwardMsgReq` to Service Decorator

### DIFF
--- a/features/0056-service-decorator/README.md
+++ b/features/0056-service-decorator/README.md
@@ -13,32 +13,38 @@ The `~service` decorator describes a DID service endpoint inline to a message.
 
 ## Motivation
 
-This allows messages to self contain endpoint and routing information normally in a DID Document. This comes in handy when DIDs or DID Documents have not been exchanged.
+This allows messages to self contain endpoint and routing information normally found in a DID Document. This comes in handy when DIDs or DID Documents have not been exchanged.
 
 Examples include the Connect Protocol and Challenge Protocols.
 
-The `~service` decorator on a message contains the service definition that you might expect to find in a DID Document. These values function the same way.
+The `~service` decorator on a message extends the service definition that you might expect to find in a DID Document.
 
 ## Tutorial
 
-Usage looks like this, with the contents defined the [Service Endpoint section of the DID Spec](https://w3c-ccg.github.io/did-spec/#service-endpoints):
+Usage looks like this, extending the contents defined in the [Service Endpoint section of the DID Spec](https://w3c-ccg.github.io/did-spec/#service-endpoints):
 
-```json=
+```json
 {
     "@type": "somemessagetype",
     "~service": {
         "recipientKeys": ["8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"],
-        "routingKeys": ["8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"]
-        "serviceEndpoint": "https://example.com/endpoint"
+        "routingKeys": ["8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"],
+        "serviceEndpoint": "https://example.com/endpoint",
+        "forwardMsgReq": "did:example:aYgjkk34JDJKLJh;service=schema/exampleschema/1.0/exampletype"   # optional
     }
 }
 ```
 
+`forwardMsgReq` is optional and its value is a URI for a schema:
 
+* The inclusion of `forwardMsgReq` signals to the Sender that `forwardMsg` is required on the *Forward* message in order for the message to reach the Recipient.
+* There are no restrictions on the language used to describe the schema so long as both parties (sender, router) understand it.
+
+The combination of `forwardMsgReq` and `forwardMsg` enable more sofisticated gatekeeping as described in [Indy HIPE 0022 - Cross Domain Messaging](https://github.com/hyperledger/indy-hipe/tree/master/text/0022-cross-domain-messaging).
 
 ## Reference
 
-The contents of the `~service` decorator are defined by the  [Service Endpoint section of the DID Spec](https://w3c-ccg.github.io/did-spec/#service-endpoints).
+The base contents of the `~service` decorator are defined by the  [Service Endpoint section of the DID Spec](https://w3c-ccg.github.io/did-spec/#service-endpoints).
 
 The decorator should not be used when the message recipient already has a service endpoint. 
 

--- a/features/0056-service-decorator/README.md
+++ b/features/0056-service-decorator/README.md
@@ -40,7 +40,7 @@ Usage looks like this, extending the contents defined in the [Service Endpoint s
 * The inclusion of `forwardMsgReq` signals to the Sender that `forwardMsg` is required on the *Forward* message in order for the message to reach the Recipient.
 * There are no restrictions on the language used to describe the schema so long as both parties (sender, router) understand it.
 
-The combination of `forwardMsgReq` and `forwardMsg` enable more sofisticated gatekeeping as described in [Indy HIPE 0022 - Cross Domain Messaging](https://github.com/hyperledger/indy-hipe/tree/master/text/0022-cross-domain-messaging).
+The combination of `forwardMsgReq` and `forwardMsg` enable more sophisticated gatekeeping as described in [Indy HIPE 0022 - Cross Domain Messaging](https://github.com/hyperledger/indy-hipe/tree/master/text/0022-cross-domain-messaging).
 
 ## Reference
 


### PR DESCRIPTION
**Motivation**
* Allow more sophisticated gatekeeping by mediators/routers as described in [HIPE 0022 - Cross Domain Messaging](https://github.com/hyperledger/indy-hipe/tree/master/text/0022-cross-domain-messaging).
* Provide a way to signal to the Sender that a message for the mediator/router is required for gatekeeping

**Changes**
* Adds a new attribute to the `~service` decorator
* Tweaked the language around the definition of `~service` to say that it *extends* the `service` attribute in the DID Spec, as opposed to being entirely defined by it. Reasons:
   * DID*Comms* ("routers", "routing keys") should not leak into the DID Spec
   * There already exist attributes not in the DID Spec (`routingKeys`, `recipientKeys`)

**Note:** an accompanying change is required on HIPE 0022 once it's ported over to the Aries RFCs.


Signed-off-by: George Aristy <george.aristy@securekey.com>