### PR TITLE
tweak: cleanup definitions

### DIFF
--- a/concepts/0003-protocols/README.md
+++ b/concepts/0003-protocols/README.md
@@ -94,8 +94,8 @@ not two. When the [DID Exchange Protocol](
 may involve dozens of *participants*, and it has cycles and other complex
 state evolution.
 
->See [this note](parties-roles-participants.md) for definitions of the terms
-"party", "role", and "participant".
+>See [this note](roles-participants-etc.md) for definitions of the terms
+"role", "participant", and "party".
 
 #### Agent Design
 
@@ -188,7 +188,7 @@ also attached to this RFC as an example.
 * [Message Type and Protocol Identifier URIs](uris.md)
 * [Semver Rules for Protocols](semver.md)
 * [State Details and State Machines](state-details.md)
-* [Parties, Roles, and Participants](parties-roles-participants.md)
+* [Roles, Participants, Parties, and Controllers](roles-participants-etc.md)
 
 ## Drawbacks
 

--- a/concepts/0003-protocols/roles-participants-etc.md
+++ b/concepts/0003-protocols/roles-participants-etc.md
@@ -1,4 +1,36 @@
-# Parties, Roles, Participants, and Drivers
+# Roles, Participants, Parties, and Controllers
+
+## Roles
+
+The __roles__ in a protocol are the perspectives (responsibilities, privileges) that parties take on an
+interaction. 
+
+This perspective is manifested in three general ways:
+
+ * by the expectations that a party takes on in a protocol (ex. a role may be expected to do something to start a protocol).
+ * by the messages that a party can and does use in the course of the protocol (some messages may be reserved for a single role, while other may used by some if not all roles).
+ * by the state and the transition rules
+ 
+Like parties, roles are normally known at the start of the protocol but this is not a requirement.
+
+In an auction protocol, there are only two roles--*auctioneer*
+and *bidder*--even though there may be many parties involved.
+
+## Participants
+
+The __participants__ in a protocol are the agents that consume and/or emit
+[plaintext application-level messages](
+https://github.com/hyperledger/indy-hipe/tree/master/text/0026-agent-file-format#agent-plaintext-messages-ap)
+that embody the protocol's interaction. Alice, Bob, and
+Carol may each have a cloud agent, a laptop, and a phone; if they engage in an
+introduction protocol using phones, then the agents on their phones are the participants.
+If the phones talk directly over Bluetooth, this is particularly clear--but even if the
+phones leverage push notifications and HTTP such that cloud agents help with routing,
+only the phone agents are participants, because only they maintain state for the
+interaction underway. (The cloud agents would be __facilitators__, and the laptops would
+be __bystanders__). When a protocol is complete, the participant agents know about the
+outcome; they may need to synchronize or replicate their state before other agents of the
+parties are aware.
 
 ## Parties
 
@@ -36,67 +68,16 @@ Normally, the parties that are involved in a protocol also participate in the in
 case. Consider a gossip protocol, two parties may be talking about a third party. In this case, the third party would
 not even know that the protocol was happening and would definitely not participate.
 
-## Roles
+## Controllers
 
-The __roles__ in a protocol are the perspectives (responsibilities, privileges) that parties take on an
-interaction. 
-
-This perspective is manifested in three general ways:
-
- * by the expectations that a party takes on in a protocol (ex. a role may be expected to do something to start a protocol).
- * by the messages that a party can and does use in the course of the protocol (some messages may be reserved for a single role, while other may used by some if not all roles).
- * by the state and the transition rules
- 
-Like parties, roles are normally known at the start of the protocol but this is not a requirement.
-
-In an auction protocol, there are only two roles--*auctioneer*
-and *bidder*--even though there may be many parties involved.
-
-## Participants
-
-The __participants__ in a protocol are the agents that consume and/or emit
-[plaintext application-level messages](
-https://github.com/hyperledger/indy-hipe/tree/master/text/0026-agent-file-format#agent-plaintext-messages-ap)
-that embody the protocol's interaction. Alice, Bob, and
-Carol may each have a cloud agent, a laptop, and a phone; if they engage in an
-introduction protocol using phones, then the agents on their phones are the participants.
-If the phones talk directly over Bluetooth, this is particularly clear--but even if the
-phones leverage push notifications and HTTP such that cloud agents help with routing,
-only the phone agents are participants, because only they maintain state for the
-interaction underway. (The cloud agents would be __facilitators__, and the laptops would
-be __bystanders__). When a protocol is complete, the participant agents know about the
-outcome; they may need to synchronize or replicate their state before other agents of the
-parties are aware.
-
-## Drivers
-
-The __drivers__ in a protocol are entities that make decisions. They may or may not be direct parties.
+The __controllers__ in a protocol are entities that make decisions. They may or may not be direct parties.
 
 Imagine a remote chess game between Bob and Carol, conducted with software agents. The chess protocol isn't
-technically about how to select a wise chess move; it's about communicating the moves so parties achieve
+technically about _how to select a wise chess move_; it's about _communicating the moves_ so parties achieve
 the shared goal of running a game to completion. Yet choices about moves are clearly made as the protocol
-unfolds. These choices are made by drivers--Bob and Carol--while the agents responsible for the work of
+unfolds. These choices are made by controllers--Bob and Carol--while the agents responsible for the work of
 moving the game forward wait with the protocol suspended.
 
-In this case, Bob and Carol could be analyzed as parties to the protocol, as well as drivers. But in other
+In this case, Bob and Carol could be analyzed as parties to the protocol, as well as controllers. But in other
 cases, the concepts are distinct. For example, in a protocol to issue credentials, the issuing institution
-and the 
-
-in sync.
- . Bob and Carol use software agents to play the game;
-these agents exchange messages that express the moves. These agents are tasked with the work of moving
-the game forward--but they are not tasked with winning the game. That task falls to Bob and Carol,
-who are drivers. Each time a move is made, the agent must consult the driver to get a decision about
-a counter-move.
-
-If Bob connects his software agent to an AI, then the AI becomes the driver, not Bob.
-
-
-
-
-They would have the responsibility of moving the game forward quickly and accurately. However,
-
-However, the agents are not trying to win they game; their goal is to faithfully move the game
-forwardThis is the actual work
-of making the protocol progress. However, the software agents must consult their owners to learn what move
-should come next.
+might use an AI and/or business automation as a controller.

--- a/concepts/0003-protocols/template.md
+++ b/concepts/0003-protocols/template.md
@@ -47,8 +47,8 @@ its simpler variants.
 
 ### "Roles" under "Tutorial"
 
->See [this note](parties-roles-participants.md) for definitions of the terms
-"party", "role", and "participant".
+>See [this note](roles-participants-etc.md) for definitions of the terms
+"role", "participant", and "party".
 
 The "Roles" subsection comes next in a protocol RFC. It gives a formal name
 to each role in the protocol, says who and how many can play each role, and

--- a/concepts/0003-protocols/template.md
+++ b/concepts/0003-protocols/template.md
@@ -3,7 +3,8 @@
 A protocol RFC conforms to general RFC patterns, but includes some
 specific substructure.
 
-[![template sections](template-sections.png)](https://docs.google.com/presentation/d/15UAkh_2WfDk7wlto7pSL7YU9NJr_XVMgGAOeNIRbzK8/edit#slide=id.g5609c67f13_0_113)
+[![template sections](template-sections.png)](
+https://docs.google.com/presentation/d/15UAkh_2WfDk7wlto7pSL7YU9NJr_XVMgGAOeNIRbzK8/edit#slide=id.g5609c67f13_0_113)
 
 ### "Name and Version" under "Tutorial"
 


### PR DESCRIPTION
I found some unfinished writing that needed to be deleted in the doc defining parties, roles, and participants. That doc also needed to be updated because the folks on the aries-cloudagent-python team have been popularizing the term `controller` where the doc used `driver`. Controller is better.