### PR TITLE
Update name of Aries Framework - Go

### DIFF
--- a/concepts/0003-protocols/README.md
+++ b/concepts/0003-protocols/README.md
@@ -308,7 +308,7 @@ Name / Link | Implementation Notes
 [Streetcred.id](https://streetcred.id/) | several protocols, circa Feb 2019
 [Aries Cloud Agent - Python](https://github.com/hyperledger/aries-cloudagent-python) | numerous protocols plus extension mechanism for pluggable protocols
 [Aries Static Agent - Python](https://github.com/hyperledger/aries-staticagent-python) | 2 or 3 protocols
-[Aries Go Framework](https://github.com/hyperledger/aries-framework-go) | DID Exchange
+[Aries Framework - Go](https://github.com/hyperledger/aries-framework-go) | DID Exchange
 [Connect.Me](https://www.evernym.com/blog/connect-me-sovrin-digital-wallet/) | mature but proprietary protocols; community protocols in process
 [Verity](https://www.evernym.com/products/) | mature but proprietary protocols; community protocols in process
 [Aries Protocol Test Suite](https://github.com/hyperledger/aries-protocol-test-suite) | 2 or 3 core protocols; active work to implement all that are ACCEPTED, since this tests conformance of other agents

--- a/concepts/0004-agents/README.md
+++ b/concepts/0004-agents/README.md
@@ -498,7 +498,7 @@ Name / Link | Implementation Notes
 [Streetcred.id](https://streetcred.id/) | Commercial mobile and web app built using Streetcred AgentFramework
 [Aries Cloud Agent - Python](https://github.com/hyperledger/aries-cloudagent-python) | Contributed by the government of British Columbia.
 [Aries Static Agent - Python](https://github.com/hyperledger/aries-staticagent-python) | Useful for cron jobs and other simple, automated use cases.
-[Aries Go Framework](https://github.com/hyperledger/aries-framework-go) | For building agents, hubs and other DIDComm features in GoLang.
+[Aries Framework - Go](https://github.com/hyperledger/aries-framework-go) | For building agents, hubs and other DIDComm features in GoLang.
 [Connect.Me](https://www.evernym.com/blog/connect-me-sovrin-digital-wallet/) | Free mobile app from Evernym. Installed via app store on iOS and Android. 
 [Verity](https://www.evernym.com/products/) | Commercially licensed enterprise agent, SaaS or on-prem.
 [Aries Protocol Test Suite](https://github.com/hyperledger/aries-protocol-test-suite) | 

--- a/concepts/0005-didcomm/README.md
+++ b/concepts/0005-didcomm/README.md
@@ -178,7 +178,7 @@ Name / Link | Implementation Notes
 [Streetcred.id](https://streetcred.id/) | Commercial mobile and web app built using Streetcred AgentFramework
 [Aries Cloud Agent - Python](https://github.com/hyperledger/aries-cloudagent-python) | Contributed by the government of British Columbia.
 [Aries Static Agent - Python](https://github.com/hyperledger/aries-staticagent-python) | Useful for cron jobs and other simple, automated use cases.
-[Aries Go Framework](https://github.com/hyperledger/aries-framework-go) | For building agents, hubs and other DIDComm features in GoLang.
+[Aries Framework - Go](https://github.com/hyperledger/aries-framework-go) | For building agents, hubs and other DIDComm features in GoLang.
 [Connect.Me](https://www.evernym.com/blog/connect-me-sovrin-digital-wallet/) | Free mobile app from Evernym. Installed via app store on iOS and Android. 
 [Verity](https://www.evernym.com/products/) | Commercially licensed enterprise agent, SaaS or on-prem.
 [Aries Protocol Test Suite](https://github.com/hyperledger/aries-protocol-test-suite) | 

--- a/concepts/0011-decorators/README.md
+++ b/concepts/0011-decorators/README.md
@@ -263,7 +263,7 @@ Aries RFCs: [RFC 0008](../0008-message-id-and-threading/README.md), [RFC 0017](.
 [Streetcred.id](https://streetcred.id/) | message threading
 [Aries Cloud Agent - Python](https://github.com/hyperledger/aries-cloudagent-python) | message threading, attachments
 [Aries Static Agent - Python](https://github.com/hyperledger/aries-staticagent-python) | message threading
-[Aries Go Framework](https://github.com/hyperledger/aries-framework-go) | message threading
+[Aries Framework - Go](https://github.com/hyperledger/aries-framework-go) | message threading
 [Connect.Me](https://www.evernym.com/blog/connect-me-sovrin-digital-wallet/) | message threading 
 [Verity](https://www.evernym.com/products/) | message threading
 [Aries Protocol Test Suite](https://github.com/hyperledger/aries-protocol-test-suite) | message threading 

--- a/concepts/0020-message-types/README.md
+++ b/concepts/0020-message-types/README.md
@@ -231,6 +231,6 @@ Name / Link | Implementation Notes
 [Streetcred.id](https://streetcred.id/) | Commercial mobile and web app built using Streetcred AgentFramework
 [Aries Cloud Agent - Python](https://github.com/hyperledger/aries-cloudagent-python) | Contributed by the government of British Columbia.
 [Aries Static Agent - Python](https://github.com/hyperledger/aries-staticagent-python) | Useful for cron jobs and other simple, automated use cases.
-[Aries Go Framework](https://github.com/hyperledger/aries-framework-go) | For building agents, hubs and other DIDComm features in GoLang.
+[Aries Framework - Go](https://github.com/hyperledger/aries-framework-go) | For building agents, hubs and other DIDComm features in GoLang.
 [Connect.Me](https://www.evernym.com/blog/connect-me-sovrin-digital-wallet/) | Free mobile app from Evernym. Installed via app store on iOS and Android. 
 [Verity](https://www.evernym.com/products/) | Commercially licensed enterprise agent, SaaS or on-prem. 

--- a/features/0019-encryption-envelope/README.md
+++ b/features/0019-encryption-envelope/README.md
@@ -360,5 +360,5 @@ Name / Link | Implementation Notes
 [Streetcred.id](https://streetcred.id/) | Commercial mobile and web app built using Streetcred AgentFramework
 [Aries Cloud Agent - Python](https://github.com/hyperledger/aries-cloudagent-python) | Contributed by the government of British Columbia.
 [Aries Static Agent - Python](https://github.com/hyperledger/aries-staticagent-python) | Useful for cron jobs and other simple, automated use cases.
-[Aries Go Framework](https://github.com/hyperledger/aries-framework-go) | For building agents, hubs and other DIDComm features in GoLang.
+[Aries Framework - Go](https://github.com/hyperledger/aries-framework-go) | For building agents, hubs and other DIDComm features in GoLang.
 [Aries Protocol Test Suite](https://github.com/hyperledger/aries-protocol-test-suite) | 


### PR DESCRIPTION
Updates the name of https://github.com/hyperledger/aries-framework-go to have a similar style to some of the other Hyperledger hosted projects.

Signed-off-by: Troy Ronda <troy@troyronda.com>