### PR TITLE
Why the Cred Exchange RFCs don't provide credential exchange data structure details

### DIFF
--- a/features/0036-issue-credential/README.md
+++ b/features/0036-issue-credential/README.md
@@ -27,6 +27,8 @@ The Issue Credential protocol consists of these messages:
 
 In addition, the [`ack`](../0015-acks/README.md) and [`problem-report`](../0035-report-problem/README.md) messages are adopted into the protocol for confirmation and error handling.
 
+This protocol is about the messages to support issuing verifiable credentials, not about the specifics of particular verifiable credential mechanisms. This is challenging since at the time of writing this version of the protocol, there is only one supported verifiable credential mechanism (Hyperledger Indy). [DIDComm attachments](../../concepts/0017-attachments/README.md) are deliberately used in messages to try to make this protocol agnostic to the specific verifiable credential mechanism payloads. Links are provided in the message data element descriptions to details of specific verifiable credential implementation data structures.
+
 #### Choreography Diagram:
 
 ##### Issuance staring with Offer

--- a/features/0036-issue-credential/README.md
+++ b/features/0036-issue-credential/README.md
@@ -29,6 +29,13 @@ In addition, the [`ack`](../0015-acks/README.md) and [`problem-report`](../0035-
 
 This protocol is about the messages to support issuing verifiable credentials, not about the specifics of particular verifiable credential mechanisms. This is challenging since at the time of writing this version of the protocol, there is only one supported verifiable credential mechanism (Hyperledger Indy). [DIDComm attachments](../../concepts/0017-attachments/README.md) are deliberately used in messages to try to make this protocol agnostic to the specific verifiable credential mechanism payloads. Links are provided in the message data element descriptions to details of specific verifiable credential implementation data structures.
 
+Diagrams in this protocol were made in draw.io. To make changes:
+
+- upload the drawing HTML from this folder to the [draw.io](https://draw.io) site (Import From...GitHub), 
+- make changes,
+- export the picture and HTML to your local copy of this repo, and
+- submit a pull request.
+
 #### Choreography Diagram:
 
 ##### Issuance staring with Offer
@@ -260,8 +267,6 @@ Similar (but simplified) credential exchanged was already implemented in [von-an
 - It is a common practice when changing some attributes in credential to revoke the old credential and issue a new one. It might be useful to have an element in the `offer-credential` message to indicate a connection between a now revoked credential and the new credential being offered.
 - We might need some explicit documentation for nested `@type` fields.
 - There should be a way to ask for some payment with `offer-credential` and to send a payment (or payment receipt) in the request-credential.
-
-Diagrams were made in draw.io. To make some changes you can just upload the HTML from this repo to this site.
 
 ## Implementations
 

--- a/features/0037-present-proof/README.md
+++ b/features/0037-present-proof/README.md
@@ -28,6 +28,13 @@ In addition, the [`ack`](../0015-acks/README.md) and [`problem-report`](../0035-
 
 This protocol is about the messages to support the presentation of verifiable claims, not about the specifics of particular verifiable presentation mechanisms. This is challenging since at the time of writing this version of the protocol, there is only one supported verifiable presentation mechanism(Hyperledger Indy). [DIDComm attachments](../../concepts/0017-attachments/README.md) are deliberately used in messages to try to make this protocol agnostic to the specific verifiable presentation mechanism payloads. Links are provided in the message data element descriptions to details of specific verifiable presentation implementation data structures.
 
+Diagrams in this protocol were made in draw.io. To make changes:
+
+- upload the drawing HTML from this folder to the [draw.io](https://draw.io) site (Import From...GitHub), 
+- make changes,
+- export the picture and HTML to your local copy of this repo, and
+- submit a pull request.
+
 #### Choreography Diagram:
 
 ![present proof](credential-presentation.png)
@@ -118,32 +125,6 @@ Description of fields:
 * `comment` -- a field that provides some human readable information about this presentation.
 * `presentations~attach` -- an array of attachments containing the presentation in the requested format(s).
   * For Indy, the attachment contains data from libindy that is the presentation, base64 encoded. The following JSON is an example of the `libindy-presentation-0` attachment content. For more information see the [Libindy API](https://github.com/hyperledger/indy-sdk/blob/57dcdae74164d1c7aa06f2cccecaae121cefac25/libindy/src/api/anoncreds.rs#L1404).
-
-```json
-{
-     "requested_proof": {
-         "revealed_attrs": {
-             "requested_attr1_id": {sub_proof_index: number, raw: string, encoded: string},
-             "requested_attr4_id": {sub_proof_index: number: string, encoded: string},
-         },
-         "unrevealed_attrs": {
-             "requested_attr3_id": {sub_proof_index: number}
-         },
-         "self_attested_attrs": {
-             "requested_attr2_id": self_attested_value,
-         },
-         "requested_predicates": {
-             "requested_predicate_1_referent": {sub_proof_index: int},
-             "requested_predicate_2_referent": {sub_proof_index: int},
-         }
-     },
-     "proof": {
-         "proofs": [ <credential_proof>, <credential_proof>, <credential_proof> ],
-         "aggregated_proof": <aggregated_proof>
-     },
-     "identifiers": [{schema_id, cred_def_id, Optional<rev_reg_id>, Optional<timestamp>}]
-}
-```
 
 #### Presentation Preview
 
@@ -238,8 +219,6 @@ Similar (but simplified) credential exchange was already implemented in [von-anc
 
 - We might need some explicit documentation for nested `@type` fields.
 - There might need to be a way to associate a payment with the present proof protocol.
-
-Diagrams were made in draw.io. To make some changes you can just upload the HTML from this repo to this site.
 
 ## Implementations
 

--- a/features/0037-present-proof/README.md
+++ b/features/0037-present-proof/README.md
@@ -26,6 +26,8 @@ The present proof protocol consists of these messages:
 
 In addition, the [`ack`](../0015-acks/README.md) and [`problem-report`](../0035-report-problem/README.md) messages are adopted into the protocol for confirmation and error handling.
 
+This protocol is about the messages to support the presentation of verifiable claims, not about the specifics of particular verifiable presentation mechanisms. This is challenging since at the time of writing this version of the protocol, there is only one supported verifiable presentation mechanism(Hyperledger Indy). [DIDComm attachments](../../concepts/0017-attachments/README.md) are deliberately used in messages to try to make this protocol agnostic to the specific verifiable presentation mechanism payloads. Links are provided in the message data element descriptions to details of specific verifiable presentation implementation data structures.
+
 #### Choreography Diagram:
 
 ![present proof](credential-presentation.png)


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>

Addresses issue #168.  Links to the Indy specific data structures were already included in the RFCs.

Clarifies how to edit the flow diagrams.  Removes an instance of an Indy data structure that we had agreed should not be covered in the RFC.