### PR TITLE
Minor editorial changes to DCO Sign Off instructions

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -140,15 +140,17 @@ We use developer certificate of origin (DCO) in all hyperledger repositories, so
 The `-s` flag signs the commit message with your name and email.
 
 #### How to Sign Previous Commits
-   1. Use `git log --show-signature` to see which commits need to be signed.
-   1. Go into interactive rebase mode using `$ git rebase -i HEAD~X` where X is the number of commits up to the most current commit you would like to see.
-   1. You will see a list of the commits in a text file. **On the line after each commit you need to sign**, add `exec git commit --amend --no-edit -s` with the lowercase `-s` adding a text signature in the commit body. Example that signs both commits:
-      ```
-      pick 12345 commit message
-      exec git commit --amend --no-edit -s
-      pick 67890 commit message
-      exec git commit --amend --no-edit -s
-      ```
-    1. If you need to re-sign a bunch of previous commits at once, find the earliest unsigned commit using `git log --show-signature` and use that the HASH of the commit before it in this command: `git rebase --exec 'git commit --amend --no-edit -n -s' -i HASH`. This will sign every commit from most recent to right before the HASH.
-    1. You will probably need to do a force push `git push -f` if you had previously pushed unsigned commits to remote.
 
+1. Use `git log --show-signature` to see which commits need to be signed.
+2. Go into interactive rebase mode using `$ git rebase -i HEAD~X` where X is the number of commits up to the most current commit you would like to see.
+3. You will see a list of the commits in a text file. **On the line after each commit you need to sign**, add `exec git commit --amend --no-edit -s` with the lowercase `-s` adding a text signature in the commit body. Example that signs both commits:
+
+   ```
+   pick 12345 commit message
+   exec git commit --amend --no-edit -s
+   pick 67890 commit message
+   exec git commit --amend --no-edit -s
+   ```
+
+4. If you need to re-sign a bunch of previous commits at once, find the earliest unsigned commit using `git log --show-signature` and use that the HASH of the commit before it in this command: `git rebase --exec 'git commit --amend --no-edit -n -s' -i HASH`. This will sign every commit from most recent to right before the HASH.
+5. You will probably need to do a force push `git push -f` if you had previously pushed unsigned commits to remote.

--- a/contributing.md
+++ b/contributing.md
@@ -126,9 +126,9 @@ This means that any contributions you make must be licensed in an Apache-2-compa
 way, and must be free from patent encumbrances or additional terms and conditions. By
 raising a PR, you certify that this is the case for your contribution.
 
-### Signing commits (DCO)
+### Signing off commits (DCO)
 
-If you are here because you forgot to sign your commits, fear not. Check out [how to sign previous commits](#how-to-sign-previous-commits)
+If you are here because you forgot to sign off your commits, fear not. Check out [how to sign off previous commits](#how-to-sign-off-previous-commits)
 
 We use developer certificate of origin (DCO) in all hyperledger repositories, so to get your pull requests accepted, you must certify your commits by signing off on each commit.
 
@@ -137,13 +137,13 @@ We use developer certificate of origin (DCO) in all hyperledger repositories, so
   - To see if your commits have been signed off, run `$ git log --show-signature`
   - If you need to re-sign the most current commit, use `$ git commit --amend --no-edit -s`.
 
-The `-s` flag signs the commit message with your name and email.
+The `-s` flag signs off the commit message with your name and email.
 
-#### How to Sign Previous Commits
+#### How to Sign Off Previous Commits
 
-1. Use `git log --show-signature` to see which commits need to be signed.
+1. Use `git log --show-signature` to see which commits need to be signed off.
 2. Go into interactive rebase mode using `$ git rebase -i HEAD~X` where X is the number of commits up to the most current commit you would like to see.
-3. You will see a list of the commits in a text file. **On the line after each commit you need to sign**, add `exec git commit --amend --no-edit -s` with the lowercase `-s` adding a text signature in the commit body. Example that signs both commits:
+3. You will see a list of the commits in a text file. **On the line after each commit you need to sign off**, add `exec git commit --amend --no-edit -s` with the lowercase `-s` adding a text signature in the commit body. Example that signs both commits:
 
    ```
    pick 12345 commit message
@@ -152,5 +152,5 @@ The `-s` flag signs the commit message with your name and email.
    exec git commit --amend --no-edit -s
    ```
 
-4. If you need to re-sign a bunch of previous commits at once, find the earliest unsigned commit using `git log --show-signature` and use that the HASH of the commit before it in this command: `git rebase --exec 'git commit --amend --no-edit -n -s' -i HASH`. This will sign every commit from most recent to right before the HASH.
+4. If you need to re-sign a bunch of previous commits at once, find the earliest unsigned commit using `git log --show-signature` and use that the HASH of the commit before it in this command: `git rebase --exec 'git commit --amend --no-edit -n -s' -i HASH`. This will sign off every commit from most recent to right before the HASH.
 5. You will probably need to do a force push `git push -f` if you had previously pushed unsigned commits to remote.

--- a/contributing.md
+++ b/contributing.md
@@ -130,18 +130,18 @@ raising a PR, you certify that this is the case for your contribution.
 
 If you are here because you forgot to sign off your commits, fear not. Check out [how to sign off previous commits](#how-to-sign-off-previous-commits)
 
-We use developer certificate of origin (DCO) in all hyperledger repositories, so to get your pull requests accepted, you must certify your commits by signing off on each commit.
+We use developer certificate of origin (DCO) in all Hyperledger repositories, so to get your pull requests accepted, you must certify your commits by signing off on each commit.
 
-#### Signing your current commit
+#### Signing off your current commit
   - `$ git commit -s -m "your commit message"`
-  - To see if your commits have been signed off, run `$ git log --show-signature`
+  - To see if your commits have been signed off, run `$ git log`. Any commits including a line with `Signed-off-by: Example Author <author.email@example.com>` are signed off.
   - If you need to re-sign the most current commit, use `$ git commit --amend --no-edit -s`.
 
 The `-s` flag signs off the commit message with your name and email.
 
 #### How to Sign Off Previous Commits
 
-1. Use `git log --show-signature` to see which commits need to be signed off.
+1. Use `$ git log` to see which commits need to be signed off. Any commits missing a line with `Signed-off-by: Example Author <author.email@example.com>` need to be re-signed.
 2. Go into interactive rebase mode using `$ git rebase -i HEAD~X` where X is the number of commits up to the most current commit you would like to see.
 3. You will see a list of the commits in a text file. **On the line after each commit you need to sign off**, add `exec git commit --amend --no-edit -s` with the lowercase `-s` adding a text signature in the commit body. Example that signs both commits:
 
@@ -152,5 +152,10 @@ The `-s` flag signs off the commit message with your name and email.
    exec git commit --amend --no-edit -s
    ```
 
-4. If you need to re-sign a bunch of previous commits at once, find the earliest unsigned commit using `git log --show-signature` and use that the HASH of the commit before it in this command: `git rebase --exec 'git commit --amend --no-edit -n -s' -i HASH`. This will sign off every commit from most recent to right before the HASH.
-5. You will probably need to do a force push `git push -f` if you had previously pushed unsigned commits to remote.
+4. If you need to re-sign a bunch of previous commits at once, find the earliest commit missing the sign off line using `$ git log` and use that the HASH of the commit before it in this command:
+   ```
+	$ git rebase --exec 'git commit --amend --no-edit -n -s' -i HASH.
+   ```
+   This will sign off every commit from most recent to right before the HASH.
+
+5. You will probably need to do a force push (`$ git push -f`) if you had previously pushed unsigned commits to remote.


### PR DESCRIPTION
I added some additional clarifications to the instructions for DCO Sign off in contributing.md. In the past, we've had several people get confused by "signing" versus "signing off" their commits, often leading new developers to go down the rabbit hole of actually signing their commits with gpg. I hope these changes will clearly distinguish signing off from signing commits.