### PR TITLE
align impact text ("message") with spec

### DIFF
--- a/features/0035-report-problem/README.md
+++ b/features/0035-report-problem/README.md
@@ -193,7 +193,7 @@ Each item in the list must be a tagged pair (a JSON {key:value}, where the key n
 
 **impact**: A string describing the breadth of impact of the problem. An enumerated type:
 
-- “msg” (this is a problem with a single message only; the rest of the interaction may still be fine),
+- “message” (this is a problem with a single message only; the rest of the interaction may still be fine),
 - “thread” (this is a problem that endangers or invalidates the entire thread),
 - “connection” (this is a problem that endangers or invalidates the entire connection).
 


### PR DESCRIPTION
Should both be 'msg', or 'message': I chose 'message' because the original text spelled out all other choices.

Signed-off-by: sklump <srklump@hotmail.com>