### PR TITLE
Fixing line wrap in 0048

### DIFF
--- a/features/0048-trust-ping/README.md
+++ b/features/0048-trust-ping/README.md
@@ -60,8 +60,8 @@ creates a `ping` message like this:
 }
 ```
 
-Only `@type` and `@id` are required; `~timing.out_time`, `~timing.expires_time`, and `~timing.delay_milli`
-are optional [message timing decorators](
+Only `@type` and `@id` are required; `~timing.out_time`, `~timing.expires_time`, 
+and `~timing.delay_milli` are optional [message timing decorators](
 ../0032-message-timing/README.md), and `comment`
 follows the conventions of [localizable message fields](
 ../0043-l10n/README.md). If present, it may
@@ -121,7 +121,11 @@ mechanism](../0034-message-tracing/README.md).
 
 ## Implementations
 
-The following lists the implementations (if any) of this RFC. Please do a pull request to add your implementation. If the implementation is open source, include a link to the repo or to the implementation within the repo. Please be consistent in the "Name" field so that a mechanical processing of the RFCs can generate a list of all RFCs supported by an Aries implementation.
+The following lists the implementations (if any) of this RFC. Please do a pull 
+request to add your implementation. If the implementation is open source, 
+include a link to the repo or to the implementation within the repo. Please be 
+consistent in the "Name" field so that a mechanical processing of the RFCs can 
+generate a list of all RFCs supported by an Aries implementation.
 
 Name / Link | Implementation Notes
 --- | ---


### PR DESCRIPTION
Fixing a single line of word wrap as part of exercise in Hyperledger Maintainers Summit/Forum.

Signed-off-by: DavidCecchi <david_cecchi@cargill.com>