### PR TITLE
Update RFC 0281: Rich Schemas

### DIFF
--- a/features/0281-rich-schemas/README.md
+++ b/features/0281-rich-schemas/README.md
@@ -1,5 +1,5 @@
-# Aries RFC 0281: Aries SDK Rich Schema Schemas
-- Authors: [Brent Zundel](brent.zundel@evernym.com), [Ken Ebert](ken@sovrin.org)
+# Aries RFC 0281: Aries Rich Schemas
+- Authors: [Brent Zundel](<brent.zundel@evernym.com>), [Ken Ebert](<ken@sovrin.org>)
 - Status: [PROPOSED](/README.md#proposed)
 - Since: 2019-10-30
 - Status Note: Part of proposed Rich Schema capabilities for credentials 
@@ -150,7 +150,7 @@ for anonymous credentials, as discussed in the
 the rich schema overview RFC.
 
 ### Data Registry Storage
-Aries-SDK will provide a means for writing `schema` objects to and reading
+Aries will provide a means for writing `schema` objects to and reading
 `schema` objects from a verifiable data registry (such as a distributed
 ledger).
 

--- a/index.md
+++ b/index.md
@@ -71,7 +71,7 @@
 * [0257: Private Credential Issuance](concepts/0257-private-credential-issuance/README.md) (2019-10-16 &mdash; [`concept`](/tags.md#concept) [`protocol`](/tags.md#protocol))
 * [0268: Unified DIDCOMM Deeplinking](concepts/0268-unified-didcomm-agent-deeplinking/README.md) (2019-10-23  &mdash; [`concept`](/tags.md#concept) [`agents`](/tags.md#agents) [`mobile`](/tags.md#mobile))
 * [0270: Interop Test Suite](concepts/0270-interop-test-suite/README.md) (2019-10-25 &mdash; [`concept`](/tags.md#concept))
-* [0281: Aries SDK Rich Schema Schemas](features/0281-rich-schema-schemas/README.md) (2019-10-30 &mdash; [`feature`](/tags.md#feature) [`rich-schemas`](/tags.md#rich-schemas))
+* [0281: Aries Rich Schemas](features/0281-rich-schemas/README.md) (2019-10-30 &mdash; [`feature`](/tags.md#feature) [`rich-schemas`](/tags.md#rich-schemas))
 
 ## [RETIRED](README.md#retired)
 


### PR DESCRIPTION
changed name of rich schema schemas to rich schemas, fixed errors.
Signed-off-by: Brent <brent.zundel@gmail.com>