### PR TITLE
Rename `signers` property to `signer` in signature decorator

### DIFF
--- a/features/0234-signature-decorator/README.md
+++ b/features/0234-signature-decorator/README.md
@@ -46,7 +46,7 @@ Digitally signing the `msg` object with the `ed25519sha256_single` scheme result
       "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single",
       "sig_data": "base64URL(64bit_integer_from_unix_epoch|msg_object)",
       "signature": "base64URL(digital signature function output)",
-      "signers": "base64URL(inlined_signing_verkey)"
+      "signer": "base64URL(inlined_signing_verkey)"
     }
 }
 ```
@@ -116,7 +116,7 @@ Since digital signatures are non-repudiable, it's worth noting the privacy impli
 - No, rather the receiver of the message can send an error response if they're unable to validate the signature.
 
 *How should multiple signatures be represented?*
-- One solution is to do [<digital_sig1>, <digital_sig2>] for `signature` and do [<verkey1>, <verkey2>] for `signers`
+- While not supported in this version, one solution would be to support `[digital_sig1, digital_sig2]` for `signature` and `[verkey1, verkey2]` for `signer`.
 
 ## Implementations
 

--- a/features/0234-signature-decorator/ed25519sha256_single.md
+++ b/features/0234-signature-decorator/ed25519sha256_single.md
@@ -11,22 +11,22 @@ This scheme computes a single [ed25519](https://ed25519.cr.yp.to/) digital signa
     "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single",
     "sig_data": "base64URL(64bit_integer_from_unix_epoch|msg)",
     "signature": "base64URL(ed25519 signature)",
-    "signers": "base64URL(inlined_ed25519_signing_verkey)"
+    "signer": "base64URL(inlined_ed25519_signing_verkey)"
 }
 ```
 
 * `@type` MUST be `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single`
 * `sig_data` MUST be the base64URL encoding of a 64-bit integer prepended to the message
 * `signature` MUST be the base64URL encoding of the resulting ed25519 digital signature over `sig_data`
-* `signers` MUST be the base64URL encoding of the corresponding ed25519 public key used to sign `sig_data`
+* `signer` MUST be the base64URL encoding of the corresponding ed25519 public key used to sign `sig_data`
 
 ### Verification
 
 The successful outcome of this scheme is the `plaintext`.
 
-1. base64URL-decode `signers`
+1. base64URL-decode `signer`
 2. base64URL-decode `signature`
-3. Verify the ed25519 signature over `sig_data` with the key provided in `signers`
+3. Verify the ed25519 signature over `sig_data` with the key provided in `signer`
    1. Further processing is halted if verification fails and an "authentication failure" error is returned
 4. base64URL-decode the `sig_data`
 5. Strip out the first 8 bytes


### PR DESCRIPTION
Proposed because existing implementations in ACA-py and aries-framework-dotnet only support the `signer` property and the spec only defines support for a single signature (with a suggestion toward supporting multiple signatures in future). The signature decorator is also likely to be retired as the functionality is added to the `attach` decorator.  @kdenhartog @dhh1128 @swcurran 