### PR TITLE
allow empty commits on action

### DIFF
--- a/.github/workflows/indexgenerate.yml
+++ b/.github/workflows/indexgenerate.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git commit -m "Generate Index" -a
+        git commit -m "Generate Index" -a --allow-empty
     - name: Push changes
       uses: ad-m/github-push-action@v0.5.0
       with:


### PR DESCRIPTION
this will prevent errors when a PR results in no change to the index.