### PR TITLE
Referents for attributes in presentation proposals

### DIFF
--- a/features/0037-present-proof/README.md
+++ b/features/0037-present-proof/README.md
@@ -123,7 +123,8 @@ This is not a message but an inner object for other messages in this protocol. I
             "name": "<attribute_name>",
             "cred_def_id": "<cred_def_id>",
             "mime-type": "<type>",
-            "value": "<value>"
+            "value": "<value>",
+            "referent": "<referent>"
         },
         // more attributes
     ],
@@ -165,8 +166,41 @@ The optional `value`, when present, holds the value of the attribute to reveal i
 An attribute specification must specify a `value`, a `cred_def_id`, or both: 
 
 * if `value` is present and `cred_def_id` is absent, the preview proposes a self-attested attribute;
-* if `value` and `cred_def_id` are both present, the preview proposes verifiable claim to reveal in the presentation;
-* if `value` is absent and `cred_def_id` is present, the preview proposes verifiable claim not to reveal in the presentation.
+* if `value` and `cred_def_id` are both present, the preview proposes a verifiable claim to reveal in the presentation;
+* if `value` is absent and `cred_def_id` is present, the preview proposes a verifiable claim not to reveal in the presentation.
+
+##### Referent
+
+The optional `referent` can be useful in specifying multiple-credential presentations. Its value indicates which credential 
+will supply the attribute in the presentation. Sharing a `referent` value between multiple attribute specifications indicates that the holder's same credential supplies the attribute.
+
+Any attribute specification using a `referent` must also have a `cred_def_id`; any attribute specifications sharing a common `referent` value must all have the same `cred_def_id` value.
+
+For example, a holder with multiple account credentials could use a presentation preview such as
+
+```jsonc
+{
+    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/presentation-preview",
+    "attributes": [
+        {
+            "name": "account",
+            "cred_def_id": "BzCbsNYhMrjHiqZDTUASHg:3:CL:1234:tag",
+            "value": "12345678",
+            "referent": "0"
+        },
+        {
+            "name": "streetAddress",
+            "cred_def_id": "BzCbsNYhMrjHiqZDTUASHg:3:CL:1234:tag",
+            "value": "123 Main Street",
+            "referent": "0"
+        },
+    ],
+    "predicates": [
+    ]
+}
+```
+
+to prompt a verifier to request proof of account number and street address from the same account, rather than potentially an account number and street address from distinct accounts.
 
 #### Predicates
 

--- a/features/0037-present-proof/README.md
+++ b/features/0037-present-proof/README.md
@@ -152,7 +152,9 @@ The mandatory `"name"` key maps to the name of the attribute.
 
 ##### Credential Definition Identifier
 
-The optional `"cred_def_id"` key maps to the credential definition identifier of the credential with the current attribute. If the key is absent, the preview specifies attribute's posture in the presentation as a self-attested attribute.
+The optional `"cred_def_id"` key maps to the credential definition identifier of the credential with the current attribute - note that since it is the holder who creates the preview and the holder possesses the corresponding credential, the holder must know its credential definition identifier.
+
+If the key is absent, the preview specifies attribute's posture in the presentation as a self-attested attribute. A self-attested attribute does not come from a credential, and hence any attribute specification without the `"cred_def_id"` key cannot use a `"referent"` key.
 
 ##### MIME Type and Value
 
@@ -174,7 +176,7 @@ An attribute specification must specify a `value`, a `cred_def_id`, or both:
 The optional `referent` can be useful in specifying multiple-credential presentations. Its value indicates which credential 
 will supply the attribute in the presentation. Sharing a `referent` value between multiple attribute specifications indicates that the holder's same credential supplies the attribute.
 
-Any attribute specification using a `referent` must also have a `cred_def_id`; any attribute specifications sharing a common `referent` value must all have the same `cred_def_id` value.
+Any attribute specification using a `referent` must also have a `cred_def_id`; any attribute specifications sharing a common `referent` value must all have the same `cred_def_id` value (see [credential-definition-identifier] above).
 
 For example, a holder with multiple account credentials could use a presentation preview such as
 
@@ -208,11 +210,7 @@ The mandatory `"predicates"` key maps to a list (possibly empty to propose a pre
 
 ##### Attribute Name
 
-The mandatory `"name"` key maps to the name of the attribute germane to the predicate.
-
-##### Credential Definition Identifier
-
-The mandatory `"cred_def_id"` key maps to the credential definition identifier of the credential with the current attribute.
+The mandatory `"name"` key maps to the name of the attribute.
 
 ##### Predicate
 
@@ -224,12 +222,16 @@ The mandatory `"threshold"` key maps to the threshold value for the predicate.
 
 ##### Filter
 
-The mandatory `"filter"` key maps to an object with one or more criteria disjunctively (via "or") applicable to the attribute as a claim.
+The mandatory `"filter"` key maps to an object with zero or more criteria disjunctively (via "or") applicable to the attribute as a claim.
 
 Filter keys include:
 
-* `"cred_def_id"` to specify a credential definition identifier
 * `"schema_id"` to specify a schema identifier
+* `"schema_issuer_did"` to specify a schema issuer DID
+* `"schema_name"` to specify a schema name
+* `"schema_version"` to specify a schema version
+* `"cred_def_id"` to specify a credential definition identifier
+* `"issuer_did"` to specify a credential issuer DID
 * any other criteria that both the holder and verifier understand in the context of presentation creation.
 
 ## Negotiation and Preview

--- a/features/0037-present-proof/README.md
+++ b/features/0037-present-proof/README.md
@@ -222,16 +222,12 @@ The mandatory `"threshold"` key maps to the threshold value for the predicate.
 
 ##### Filter
 
-The mandatory `"filter"` key maps to an object with zero or more criteria disjunctively (via "or") applicable to the attribute as a claim.
+The mandatory `"filter"` key maps to an object with one or more criteria disjunctively (via "or") applicable to the attribute as a claim.
 
 Filter keys include:
 
 * `"schema_id"` to specify a schema identifier
-* `"schema_issuer_did"` to specify a schema issuer DID
-* `"schema_name"` to specify a schema name
-* `"schema_version"` to specify a schema version
 * `"cred_def_id"` to specify a credential definition identifier
-* `"issuer_did"` to specify a credential issuer DID
 * any other criteria that both the holder and verifier understand in the context of presentation creation.
 
 ## Negotiation and Preview

--- a/features/0037-present-proof/README.md
+++ b/features/0037-present-proof/README.md
@@ -212,6 +212,10 @@ The mandatory `"predicates"` key maps to a list (possibly empty to propose a pre
 
 The mandatory `"name"` key maps to the name of the attribute.
 
+##### Credential Definition Identifier
+
+The mandatory `"cred_def_id"` key maps to the credential definition identifier of the credential with the current attribute.
+
 ##### Predicate
 
 The mandatory `"predicate"` key maps to the predicate operator: `"<"`, `"<="`, `">="`, `">"`. 

--- a/features/0335-http-over-didcomm/README.md
+++ b/features/0335-http-over-didcomm/README.md
@@ -20,6 +20,10 @@ Carl wants to apply for a car loan from his friendly neighborhood used car deale
 
 HTTP over DIDComm turns a dev + ops problem, of redesigning and deploying your server and client to use DID communication, into an ops problem - deploying Aries infrastructure in front of your server and to your clients.
 
+Using HTTP over DIDComm as opposed to HTTPS between a client and server offers some key benefits:
+- The client and server can use methods provided by Aries agents to verify their trust in the other party - for example, by presenting verifiable credential proofs. In particular, this allows decentralized client verification and trust, as opposed to client certs.
+- The client and server can be blind to each others' identities (for example, using fresh peer DIDs and communicating through a router), even while using their agents to ensure trust.
+
 ## Tutorial
 
 #### Name and Version
@@ -51,7 +55,7 @@ The entities involved in this protocol are as follows:
  
 ![HTTP client and server communicate over DIDComm](client-server-didcomm-domains.png)
 
-Before a message can be sent, the server must register with its agent using the `~purpose` decorator, registering on the `scheme://host:port/path` prefix of the each request URI it wishes to serve.
+Before a message can be sent, the server must register with its agent using the `~purpose` decorator, registering on one or more purpose tags.
 
 When a client sends an HTTP request to a client agent, the agent may need to maintain an open connection, or store a record of the client's identity/IP address, so the client can receive the coming response.
 
@@ -77,16 +81,18 @@ DIDComm messages for this protocol look as follows:
 {
   "@type": "https://didcomm.org/http-over-didcomm/1.0/request",
   "@id": "2a0ec6db-471d-42ed-84ee-f9544db9da4b",
-  "~purpose": [<partial resource uri: scheme://userinfo@host:port/path>],
+  "~purpose": [],
   "method": <method>,
   "resource-uri": <resource uri value>,
   "version": <version>,
   "headers": [],
-  ["body": b64enc(body)]
+  "body": b64enc(body)
 }
 ```
 
-The purpose decorator contains at least one element, which is the prefix of the resource URI string, up until the path (inclusive) and excluding any query or fragment.
+The `body` field is optional.
+
+The `resource-uri` field is also optional - if omitted, the server agent needs to set the uri based on the server that is being sent the message.
 
 ##### `response`
 
@@ -102,19 +108,34 @@ The purpose decorator contains at least one element, which is the prefix of the 
       "code":"",
       "string":""
   },
-  "version": "",
+  "version": <version>,
   "headers": [],
-  ["body": b64enc(body)]
+  "body": b64enc(body)
 }
 ```
 
 Responses need to indicate their target - the client who sent the request. Response DIDComm messages must include a `~thread` decorator so the client agent can correlate thread IDs with its stored HTTP connections.
+
+The `body` field is optional.
 
 #### Receiving HTTP Messages Over DIDComm
 
 Aries agents intended to receive HTTP-over-DIDComm messages have many options for how they handle them, with configuration dependent on intended use. For example:
 - Serve the message over the internet, configured to use a DNS, etc.
 - Send the message to a specific server, set in configuration, for an enterprise system where a single server is behind an agent.
+- Send the message to a server which registered for the message's purpose.
+
+In cases where a specific server or application is always the target of certain messages, the server/application should register with the server agent on the specific purpose decorator. In cases where the agent may need to invoke additional logic, the agent itself can register a custom handler.
+
+An agent may implement filtering to accept or reject requests based on any combination of the purpose, sender, and request contents.
+
+##### Purpose Value
+
+The purpose values used in the message should be values whose meanings are agreed upon by the client and server. For example, the purpose value can:
+ - indicate the required capabilities of the server that handles a request
+ - contain an anonymous identifier for the server, which has previously been communicated to the client.
+
+For example, to support the use of DIDComm as a client-anonymizing proxy, agents could use a purpose value like "web-proxy" to indicate that the HTTP request  (received by the server agent) should be made on the web.
 
 ## Reference
 
@@ -145,9 +166,21 @@ If the client agent waits for the time specified in the request keep-alive timeo
 Error codes which are returned by the server will be transported over DIDComm as normal.
 
 ##### Why HTTP/1.x?
-The protocol carries HTTP/1(.x) messages for a few reasons:
+The DIDComm messages in this protocol wrap HTTP/1(.x) messages for a few reasons:
  - Wire-level benefits of HTTP/2 are lost by wrapping in DIDComm and sending over another transport (which could itself be HTTP/2)
  - DIDComm is not, generally, intended to be a streaming or latency-critical transport layer, so HTTP responses, for example, can be sent complete, including their bodies, instead of being split into frames which are sent over DIDComm separately.
+
+The agents are free to support communicating with the client/server using HTTP/2 - the agents simply wait until they've received a complete request or response, before sending it onwards over DIDComm.
+
+##### HTTPS
+
+The client and server can use HTTPS to communicate with their agents - this protocol only specifies that the messages sent *over DIDComm* are HTTP, not HTTPS.
+
+##### Partial use of HTTP over DIDComm
+
+This protocol specifies the behaviour of clients, servers, and their agents. However, the client-side and server-side are decoupled by design, meaning a custom server or client, which obeys all the semantics in this RFC while diverging on technical details, can interoperate with other compliant applications.
+
+For example, a client-side agent can construct `request` messages based on internal logic rather than a request from an external application. On the server side, an agent can handle requests and send responses directly by registering its own listener on a purpose value, rather than having a separate application register.
 
 ## Drawbacks
 
@@ -157,11 +190,15 @@ You might find the cost too high, with wrapping your messages into HTTP messages
 
 The main alternative to the method proposed in this RFC is to implement DIDComm in your non-DIDComm applications, if you want them to be able to communicate with each other over DIDComm.
 
+Another alternative to sending HTTP messages over DIDComm is sending *HTTPS* over DIDComm, by establishing a TLS connection between the client and server over the DIDComm transport. This offers some tradeoffs and drawbacks which make it an edge case - it identifies the server with a certificate, it breaks the anonymity offered by DIDComm, and it is not necessary for security since DIDComm itself is securely encrypted and authenticated, and DIDComm messages can be transported over HTTPS as well.
+
 ## Prior art
 
 VPNs and onion routing (like Tor) provide solutions for similar use cases, but none so far use DIDs, which enable more complex use cases with privacy preservation.
 
-TLS/HTTPS, being HTTP over TLS, provides a similar transport-layer secure channel to HTTP over DIDComm. Note, this is why this RFC doesn't specify a means to perform HTTPS over DIDComm - DIDComm serves the same role as TLS does in HTTPS.
+TLS/HTTPS, being HTTP over TLS, provides a similar transport-layer secure channel to HTTP over DIDComm. Note, this is why this RFC doesn't specify a means to perform HTTPS over DIDComm - DIDComm serves the same role as TLS does in HTTPS, but offers additional benefits:
+- Verifiable yet anonymous authentication of the client, for example, using delegated credentials.
+- Access to DIDComm mechanisms, such as using the introduce protocol to connect the client and server.
 
 ## Unresolved questions
 

--- a/features/0348-transition-msg-type-to-https/README.md
+++ b/features/0348-transition-msg-type-to-https/README.md
@@ -95,3 +95,4 @@ Name / Link | Implementation Notes
 [Aries Framework - Go](https://github.com/hyperledger/aries-framework-go) | No steps completed
 [Connect.Me](https://www.evernym.com/blog/connect-me-sovrin-digital-wallet/) | No steps completed
 [Verity](https://www.evernym.com/products/) | No steps completed
+[Pico Labs](http://picolabs.io/) | No steps completed


### PR DESCRIPTION
Distinguish between a desire for a proof_req with `requested_attributes`/`referent`/`names` and one with `requested_attributes`/`referent`/`name` over multiple distinct referents.

I believe this approach represents the minimum possible change to the existing spec.