### PR TITLE
RFC 0335: Clarifications and addenda

### DIFF
--- a/features/0335-http-over-didcomm/README.md
+++ b/features/0335-http-over-didcomm/README.md
@@ -20,6 +20,10 @@ Carl wants to apply for a car loan from his friendly neighborhood used car deale
 
 HTTP over DIDComm turns a dev + ops problem, of redesigning and deploying your server and client to use DID communication, into an ops problem - deploying Aries infrastructure in front of your server and to your clients.
 
+Using HTTP over DIDComm as opposed to HTTPS between a client and server offers some key benefits:
+- The client and server can use methods provided by Aries agents to verify their trust in the other party - for example, by presenting verifiable credential proofs. In particular, this allows decentralized client verification and trust, as opposed to client certs.
+- The client and server can be blind to each others' identities (for example, using fresh peer DIDs and communicating through a router), even while using their agents to ensure trust.
+
 ## Tutorial
 
 #### Name and Version
@@ -51,7 +55,7 @@ The entities involved in this protocol are as follows:
  
 ![HTTP client and server communicate over DIDComm](client-server-didcomm-domains.png)
 
-Before a message can be sent, the server must register with its agent using the `~purpose` decorator, registering on the `scheme://host:port/path` prefix of the each request URI it wishes to serve.
+Before a message can be sent, the server must register with its agent using the `~purpose` decorator, registering on one or more purpose tags.
 
 When a client sends an HTTP request to a client agent, the agent may need to maintain an open connection, or store a record of the client's identity/IP address, so the client can receive the coming response.
 
@@ -77,16 +81,18 @@ DIDComm messages for this protocol look as follows:
 {
   "@type": "https://didcomm.org/http-over-didcomm/1.0/request",
   "@id": "2a0ec6db-471d-42ed-84ee-f9544db9da4b",
-  "~purpose": [<partial resource uri: scheme://userinfo@host:port/path>],
+  "~purpose": [],
   "method": <method>,
   "resource-uri": <resource uri value>,
   "version": <version>,
   "headers": [],
-  ["body": b64enc(body)]
+  "body": b64enc(body)
 }
 ```
 
-The purpose decorator contains at least one element, which is the prefix of the resource URI string, up until the path (inclusive) and excluding any query or fragment.
+The `body` field is optional.
+
+The `resource-uri` field is also optional - if omitted, the server agent needs to set the uri based on the server that is being sent the message.
 
 ##### `response`
 
@@ -102,19 +108,34 @@ The purpose decorator contains at least one element, which is the prefix of the 
       "code":"",
       "string":""
   },
-  "version": "",
+  "version": <version>,
   "headers": [],
-  ["body": b64enc(body)]
+  "body": b64enc(body)
 }
 ```
 
 Responses need to indicate their target - the client who sent the request. Response DIDComm messages must include a `~thread` decorator so the client agent can correlate thread IDs with its stored HTTP connections.
+
+The `body` field is optional.
 
 #### Receiving HTTP Messages Over DIDComm
 
 Aries agents intended to receive HTTP-over-DIDComm messages have many options for how they handle them, with configuration dependent on intended use. For example:
 - Serve the message over the internet, configured to use a DNS, etc.
 - Send the message to a specific server, set in configuration, for an enterprise system where a single server is behind an agent.
+- Send the message to a server which registered for the message's purpose.
+
+In cases where a specific server or application is always the target of certain messages, the server/application should register with the server agent on the specific purpose decorator. In cases where the agent may need to invoke additional logic, the agent itself can register a custom handler.
+
+An agent may implement filtering to accept or reject requests based on any combination of the purpose, sender, and request contents.
+
+##### Purpose Value
+
+The purpose values used in the message should be values whose meanings are agreed upon by the client and server. For example, the purpose value can:
+ - indicate the required capabilities of the server that handles a request
+ - contain an anonymous identifier for the server, which has previously been communicated to the client.
+
+For example, to support the use of DIDComm as a client-anonymizing proxy, agents could use a purpose value like "web-proxy" to indicate that the HTTP request  (received by the server agent) should be made on the web.
 
 ## Reference
 
@@ -145,9 +166,21 @@ If the client agent waits for the time specified in the request keep-alive timeo
 Error codes which are returned by the server will be transported over DIDComm as normal.
 
 ##### Why HTTP/1.x?
-The protocol carries HTTP/1(.x) messages for a few reasons:
+The DIDComm messages in this protocol wrap HTTP/1(.x) messages for a few reasons:
  - Wire-level benefits of HTTP/2 are lost by wrapping in DIDComm and sending over another transport (which could itself be HTTP/2)
  - DIDComm is not, generally, intended to be a streaming or latency-critical transport layer, so HTTP responses, for example, can be sent complete, including their bodies, instead of being split into frames which are sent over DIDComm separately.
+
+The agents are free to support communicating with the client/server using HTTP/2 - the agents simply wait until they've received a complete request or response, before sending it onwards over DIDComm.
+
+##### HTTPS
+
+The client and server can use HTTPS to communicate with their agents - this protocol only specifies that the messages sent *over DIDComm* are HTTP, not HTTPS.
+
+##### Partial use of HTTP over DIDComm
+
+This protocol specifies the behaviour of clients, servers, and their agents. However, the client-side and server-side are decoupled by design, meaning a custom server or client, which obeys all the semantics in this RFC while diverging on technical details, can interoperate with other compliant applications.
+
+For example, a client-side agent can construct `request` messages based on internal logic rather than a request from an external application. On the server side, an agent can handle requests and send responses directly by registering its own listener on a purpose value, rather than having a separate application register.
 
 ## Drawbacks
 
@@ -157,11 +190,15 @@ You might find the cost too high, with wrapping your messages into HTTP messages
 
 The main alternative to the method proposed in this RFC is to implement DIDComm in your non-DIDComm applications, if you want them to be able to communicate with each other over DIDComm.
 
+Another alternative to sending HTTP messages over DIDComm is sending *HTTPS* over DIDComm, by establishing a TLS connection between the client and server over the DIDComm transport. This offers some tradeoffs and drawbacks which make it an edge case - it identifies the server with a certificate, it breaks the anonymity offered by DIDComm, and it is not necessary for security since DIDComm itself is securely encrypted and authenticated, and DIDComm messages can be transported over HTTPS as well.
+
 ## Prior art
 
 VPNs and onion routing (like Tor) provide solutions for similar use cases, but none so far use DIDs, which enable more complex use cases with privacy preservation.
 
-TLS/HTTPS, being HTTP over TLS, provides a similar transport-layer secure channel to HTTP over DIDComm. Note, this is why this RFC doesn't specify a means to perform HTTPS over DIDComm - DIDComm serves the same role as TLS does in HTTPS.
+TLS/HTTPS, being HTTP over TLS, provides a similar transport-layer secure channel to HTTP over DIDComm. Note, this is why this RFC doesn't specify a means to perform HTTPS over DIDComm - DIDComm serves the same role as TLS does in HTTPS, but offers additional benefits:
+- Verifiable yet anonymous authentication of the client, for example, using delegated credentials.
+- Access to DIDComm mechanisms, such as using the introduce protocol to connect the client and server.
 
 ## Unresolved questions
 


### PR DESCRIPTION
- No longer enforces that the purpose is based on the request URI
- Added benefits of DIDComm for trust and blinding
- Client and server can use HTTP/2 to talk to their agents
- Client and server can use HTTPS to talk to their agents
- Describes rationale of not doing TLS over DIDComm
- Client and server side are decoupled, they don't both
  have to be non-didcomm apps using http to talk through
  an agent
- Message body field is optional

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>