### PR TITLE
RFC clarifications about the base64url padding on encode and decode

### DIFF
--- a/features/0019-encryption-envelope/README.md
+++ b/features/0019-encryption-envelope/README.md
@@ -193,6 +193,10 @@ The base64URL encoded `protected` decodes to this:
 4. encrypt the `message` using libsodium.crypto_aead_chacha20poly1305_ietf_encrypt_detached(message, protected_value_encoded, iv, cek) this is the ciphertext.
 5. base64URLencode the iv, ciphertext, and tag then serialize the format into the output format listed above.
 
+> **NOTE**: In the pack algorithm, the base64url encode implementation used **SHOULD** strip any padding
+> characters (per [https://tools.ietf.org/html/rfc7515](https://tools.ietf.org/html/rfc7515), top of page 5)
+>  from the encoded string.
+
 For a reference implementation, see https://github.com/hyperledger/indy-sdk/blob/master/libindy/src/commands/crypto.rs
 
 #### pack_message() return value (Anoncrypt mode)
@@ -265,11 +269,15 @@ The protected data decodes to this:
 4. encrypt the message using libsodium.crypto_aead_chacha20poly1305_ietf_encrypt_detached(message, protected_value_encoded, iv, cek) this is the ciphertext.
 5. base64URLencode the iv, ciphertext, and tag then serialize the format into the output format listed above.
 
+> **NOTE**: In the pack algorithm, the base64url encode implementation used **SHOULD** strip any padding
+> characters (per [https://tools.ietf.org/html/rfc7515](https://tools.ietf.org/html/rfc7515), top of page 5)
+>  from the encoded string.
+
 For a reference implementation, see https://github.com/hyperledger/indy-sdk/blob/master/libindy/src/commands/crypto.rs
 
 ### Unpack Message
 
-#### unpack_message() inteface
+#### unpack_message() interface
 
 unpacked_message = unpack_message(wallet_handle, jwe)
 
@@ -295,9 +303,10 @@ unpacked_message = unpack_message(wallet_handle, jwe)
         2. decrypt ciphertext using libsodium.crypto_aead_chacha20poly1305_ietf_open_detached(base64URLdecode(ciphertext_bytes), base64URLdecode(protected_data_as_bytes), base64URLdecode(nonce), cek)
         3. return `message` and `recipient_verkey` following the anoncrypt format listed below
 
+> **NOTE**: In the unpack algorithm, the base64url decode implementation used **MUST**
+> correctly decode padded and unpadded base64URL encoded data.
 
-
-For a reference implementation, see https://github.com/hyperledger/indy-sdk/blob/master/libindy/src/commands/crypto.rs
+For a reference unpack implementation, see https://github.com/hyperledger/indy-sdk/blob/master/libindy/src/commands/crypto.rs
 
 #### unpack_message() return values (authcrypt mode)
 

--- a/features/0019-encryption-envelope/README.md
+++ b/features/0019-encryption-envelope/README.md
@@ -193,10 +193,6 @@ The base64URL encoded `protected` decodes to this:
 4. encrypt the `message` using libsodium.crypto_aead_chacha20poly1305_ietf_encrypt_detached(message, protected_value_encoded, iv, cek) this is the ciphertext.
 5. base64URLencode the iv, ciphertext, and tag then serialize the format into the output format listed above.
 
-> **NOTE**: In the pack algorithm, the base64url encode implementation used **SHOULD** strip any padding
-> characters (per [https://tools.ietf.org/html/rfc7515](https://tools.ietf.org/html/rfc7515), top of page 5)
->  from the encoded string.
-
 For a reference implementation, see https://github.com/hyperledger/indy-sdk/blob/master/libindy/src/commands/crypto.rs
 
 #### pack_message() return value (Anoncrypt mode)
@@ -268,10 +264,6 @@ The protected data decodes to this:
 3. base64URLencode the `protected` value
 4. encrypt the message using libsodium.crypto_aead_chacha20poly1305_ietf_encrypt_detached(message, protected_value_encoded, iv, cek) this is the ciphertext.
 5. base64URLencode the iv, ciphertext, and tag then serialize the format into the output format listed above.
-
-> **NOTE**: In the pack algorithm, the base64url encode implementation used **SHOULD** strip any padding
-> characters (per [https://tools.ietf.org/html/rfc7515](https://tools.ietf.org/html/rfc7515), top of page 5)
->  from the encoded string.
 
 For a reference implementation, see https://github.com/hyperledger/indy-sdk/blob/master/libindy/src/commands/crypto.rs
 

--- a/features/0023-did-exchange/README.md
+++ b/features/0023-did-exchange/README.md
@@ -198,10 +198,6 @@ invitation_string = b64urlencode(<invitation_message>)
 
 During encoding, whitespace from the json string should be eliminated to keep the resulting invitation string as short as possible.
 
-> **NOTE**: In preparing the invitation, the base64url encode implementation used **SHOULD** strip any padding
-> characters (per [https://tools.ietf.org/html/rfc7515](https://tools.ietf.org/html/rfc7515), top of page 5)
-> from the encoded string.
-
 ##### Example Invitation Encoding
 
 Invitation:

--- a/features/0023-did-exchange/README.md
+++ b/features/0023-did-exchange/README.md
@@ -198,6 +198,10 @@ invitation_string = b64urlencode(<invitation_message>)
 
 During encoding, whitespace from the json string should be eliminated to keep the resulting invitation string as short as possible.
 
+> **NOTE**: In preparing the invitation, the base64url encode implementation used **SHOULD** strip any padding
+> characters (per [https://tools.ietf.org/html/rfc7515](https://tools.ietf.org/html/rfc7515), top of page 5)
+> from the encoded string.
+
 ##### Example Invitation Encoding
 
 Invitation:
@@ -222,6 +226,7 @@ Example URL:
 ```text
 http://example.com/ssi?c_i=eyJAdHlwZSI6ImRpZDpzb3Y6QnpDYnNOWWhNcmpIaXFaRFRVQVNIZztzcGVjL2Nvbm5lY3Rpb25zLzEuMC9pbnZpdGF0aW9uIiwiQGlkIjoiMTIzNDU2Nzg5MDA5ODc2NTQzMjEiLCJsYWJlbCI6IkFsaWNlIiwicmVjaXBpZW50S2V5cyI6WyI4SEg1Z1lFZU5jM3o3UFlYbWQ1NGQ0eDZxQWZDTnJxUXFFQjNuUzdaZnU3SyJdLCJzZXJ2aWNlRW5kcG9pbnQiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50Iiwicm91dGluZ0tleXMiOlsiOEhINWdZRWVOYzN6N1BZWG1kNTRkNHg2cUFmQ05ycVFxRUIzblM3WmZ1N0siXX0=
 ```
+
 Invitation URLs can be transferred via any method that can send text, including an email, SMS, posting on a website, or via a QR Code.
 
 Example URL encoded as a QR Code:
@@ -236,9 +241,12 @@ The _inviter_ will then publish or transmit the invitation URL in a manner avail
 #### Invitation Processing
 
 When they _invitee_ receives the invitation URL, there are two possible user flows that depend on the SSI preparedness of the individual. If the individual is new to the SSI universe, they will likely load the URL in a browser. The resulting page will contain instructions on how to get started by installing software or a mobile app. That install flow will transfer the invitation message to the newly installed software.
-A user that already has those steps accomplished will have the URL received by software directly. That sofware can read the invitation message directly out of the `c_i` query parameter, without loading the URL.
+A user that already has those steps accomplished will have the URL received by software directly. That software will base64URL decode the string and can read the invitation message directly out of the `c_i` query parameter, without loading the URL.
 
-If they _invitee_ wants to accept the invitation, they will use the information present in the invitation message to prepare the request
+> **NOTE**: In receiving the invitation, the base64url decode implementation used **MUST**
+> correctly decode padded and unpadded base64URL encoded data.
+
+If the _invitee_ wants to accept the invitation, they will use the information present in the invitation message to prepare the request
 
 ## 1. Exchange Request
 

--- a/features/0160-connection-protocol/README.md
+++ b/features/0160-connection-protocol/README.md
@@ -203,6 +203,10 @@ invitation_string = b64urlencode(<invitation_message>)
 
 During encoding, whitespace from the json string should be eliminated to keep the resulting invitation string as short as possible.
 
+> **NOTE**: In preparing the invitation, the base64url encode implementation used **SHOULD** strip any padding
+> characters (per [https://tools.ietf.org/html/rfc7515](https://tools.ietf.org/html/rfc7515), top of page 5)
+> from the encoded string.
+
 ##### Example Invitation Encoding
 
 Invitation:
@@ -247,9 +251,12 @@ The _inviter_ will then publish or transmit the invitation URL in a manner avail
 #### Invitation Processing
 
 When they _invitee_ receives the invitation URL, there are two possible user flows that depend on the SSI preparedness of the individual. If the individual is new to the SSI universe, they will likely load the URL in a browser. The resulting page will contain instructions on how to get started by installing software or a mobile app. That install flow will transfer the invitation message to the newly installed software.
-A user that already has those steps accomplished will have the URL received by software directly. That sofware can read the invitation message directly out of the `c_i` query parameter, without loading the URL.
+A user that already has those steps accomplished will have the URL received by software directly. That software will base64URL decode the string and can read the invitation message directly out of the `c_i` query parameter, without loading the URL.
 
-If they _invitee_ wants to accept the connection invitation, they will use the information present in the invitation message to prepare the request
+> **NOTE**: In receiving the invitation, the base64url decode implementation used **MUST**
+> correctly decode padded and unpadded base64URL encoded data.
+
+If the _invitee_ wants to accept the connection invitation, they will use the information present in the invitation message to prepare the request
 
 ## 1. Connection Request
 

--- a/features/0160-connection-protocol/README.md
+++ b/features/0160-connection-protocol/README.md
@@ -203,10 +203,6 @@ invitation_string = b64urlencode(<invitation_message>)
 
 During encoding, whitespace from the json string should be eliminated to keep the resulting invitation string as short as possible.
 
-> **NOTE**: In preparing the invitation, the base64url encode implementation used **SHOULD** strip any padding
-> characters (per [https://tools.ietf.org/html/rfc7515](https://tools.ietf.org/html/rfc7515), top of page 5)
-> from the encoded string.
-
 ##### Example Invitation Encoding
 
 Invitation:


### PR DESCRIPTION
Addresses issue #290 by clarifying in RFCs 0019 Encryption Envelope, 0023 DID Exchange and 0160 Connections that base64URL encoding algorithms SHOULD remove padding (per IETF RFC) and that base64URL decoding algorithms MUST handle base64URL strings with and without padding.