### PR TITLE
tweak: RFC 0037 removes redundant state

### DIFF
--- a/features/0037-present-proof/README.md
+++ b/features/0037-present-proof/README.md
@@ -41,8 +41,8 @@ Diagrams in this protocol were made in draw.io. To make changes:
 
 * request-sent
 * proposal-received
-* request-received
 * presentation-received
+* abandoning
 * done
 
 #### states for Prover
@@ -50,7 +50,7 @@ Diagrams in this protocol were made in draw.io. To make changes:
 * request-received
 * proposal-sent
 * presentation-sent
-* reject-sent
+* abandoning
 * done
 
 For the most part, these states map onto the transitions shown in the choreography diagram in obvious ways. However, a few subtleties are worth highlighting:


### PR DESCRIPTION
1. Verifier cannot receive a `request`. According to that `request-received` state is not possible for the Verifier. 

2. Instead of `reject-sent` I suggest rename it into some more generic name e.g `abandoning`. The `abandoning` state is responsible for sending `report-problem` message. So, when an internal error occurs or some message of the protocol were rejected (e.g by another agent) protocol goes to the `abandoning` state and sends a report problem message with a specific code e.g (errorCodeInternal, errorCodeRejected etc.).

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>