### PR TITLE
Clarification that a receiver should select one of the service block entries for the OOB response #493

### DIFF
--- a/features/0434-outofband/README.md
+++ b/features/0434-outofband/README.md
@@ -136,7 +136,9 @@ While the _receiver_ is expected to respond with an initiating message from a `h
 
 #### The `service` Item
 
-As mentioned in the description, the `service` item array is intended to be analogous to the `service` block of a DIDDoc. There are two forms of entries in the `service` item array:
+As mentioned in the description above, the `service` item array is intended to be analogous to the `service` block of a DIDDoc. When not reusing an existing connection, the receiver scans the array and selects (according to the rules described below) a service entry to use for the response to the out-of-band message.
+
+There are two forms of entries in the `service` item array:
 
 - a public DID that is resolved to retrieve it's DIDDoc service block, and
 - an inline service block.


### PR DESCRIPTION
An implementer pointed out that it was not clear that the receiver was supposed to select one of the entries from the set of service entries in the service array.