### PR TITLE
Tweaks to DID Exchange - inviter/invitee references; Attach fields; headings lint cleanup

### DIFF
--- a/features/0023-did-exchange/README.md
+++ b/features/0023-did-exchange/README.md
@@ -143,7 +143,7 @@ The _requester_ may provision a new DID according to the DID method spec. For a 
   "label": "Bob",
   "did": "B.did@B:A",
   "did_doc~attach": {
-      "@id": "B.did@B:A",
+      "@id": "d2ab6f2b-5646-4de3-8c02-762f553ab804",
       "mime-type": "application/json",
       "data": {
          "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
@@ -193,7 +193,7 @@ When a `request` responds to an implicit invitation, its `~thread.pthid` MUST co
   "label": "Bob",
   "did": "B.did@B:A",
   "did_doc~attach": {
-      "@id": "B.did@B:A",
+      "@id": "d2ab6f2b-5646-4de3-8c02-762f553ab804",
       "mime-type": "application/json",
       "data": {
          "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
@@ -222,7 +222,7 @@ When a `request` responds to an implicit invitation, its `~thread.pthid` MUST co
   "label": "Bob",
   "did": "B.did@B:A",
   "did_doc~attach": {
-      "@id": "B.did@B:A",
+      "@id": "d2ab6f2b-5646-4de3-8c02-762f553ab804",
       "mime-type": "application/json",
       "data": {
          "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
@@ -294,7 +294,7 @@ The exchange response message is used to complete the exchange. This message is 
   },
   "did": "B.did@B:A",
   "did_doc~attach": {
-      "@id": "B.did@B:A",
+      "@id": "d2ab6f2b-5646-4de3-8c02-762f553ab804",
       "mime-type": "application/json",
       "data": {
          "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",

--- a/features/0023-did-exchange/README.md
+++ b/features/0023-did-exchange/README.md
@@ -143,13 +143,17 @@ The _requester_ may provision a new DID according to the DID method spec. For a 
   "label": "Bob",
   "did": "B.did@B:A",
   "did_doc~attach": {
-     "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
-     "jws": {
-        "header": {
-           "kid": "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th"
-        },
-        "protected": "eyJhbGciOiJFZERTQSIsImlhdCI6MTU4Mzg4... (bytes omitted)",
-        "signature": "3dZWsuru7QAVFUCtTd0s7uc1peYEijx4eyt5... (bytes omitted)"
+      "@id": "B.did@B:A",
+      "mime-type": "application/json",
+      "data": {
+         "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
+         "jws": {
+            "header": {
+               "kid": "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th"
+            },
+            "protected": "eyJhbGciOiJFZERTQSIsImlhdCI6MTU4Mzg4... (bytes omitted)",
+            "signature": "3dZWsuru7QAVFUCtTd0s7uc1peYEijx4eyt5... (bytes omitted)"
+            }
       }
    }
 }
@@ -189,13 +193,17 @@ When a `request` responds to an implicit invitation, its `~thread.pthid` MUST co
   "label": "Bob",
   "did": "B.did@B:A",
   "did_doc~attach": {
-     "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
-     "jws": {
-        "header": {
-           "kid": "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th"
-        },
-        "protected": "eyJhbGciOiJFZERTQSIsImlhdCI6MTU4Mzg4... (bytes omitted)",
-        "signature": "3dZWsuru7QAVFUCtTd0s7uc1peYEijx4eyt5... (bytes omitted)"
+      "@id": "B.did@B:A",
+      "mime-type": "application/json",
+      "data": {
+         "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
+         "jws": {
+            "header": {
+               "kid": "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th"
+            },
+            "protected": "eyJhbGciOiJFZERTQSIsImlhdCI6MTU4Mzg4... (bytes omitted)",
+            "signature": "3dZWsuru7QAVFUCtTd0s7uc1peYEijx4eyt5... (bytes omitted)"
+            }
       }
    }
 }
@@ -214,13 +222,17 @@ When a `request` responds to an implicit invitation, its `~thread.pthid` MUST co
   "label": "Bob",
   "did": "B.did@B:A",
   "did_doc~attach": {
-     "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
-     "jws": {
-        "header": {
-           "kid": "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th"
-        },
-        "protected": "eyJhbGciOiJFZERTQSIsImlhdCI6MTU4Mzg4... (bytes omitted)",
-        "signature": "3dZWsuru7QAVFUCtTd0s7uc1peYEijx4eyt5... (bytes omitted)"
+      "@id": "B.did@B:A",
+      "mime-type": "application/json",
+      "data": {
+         "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
+         "jws": {
+            "header": {
+               "kid": "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th"
+            },
+            "protected": "eyJhbGciOiJFZERTQSIsImlhdCI6MTU4Mzg4... (bytes omitted)",
+            "signature": "3dZWsuru7QAVFUCtTd0s7uc1peYEijx4eyt5... (bytes omitted)"
+            }
       }
    }
 }
@@ -306,6 +318,7 @@ The key used in the signed attachment must be verified against the invitation's 
 * The `~thread` block contains a `thid` reference to the `@id` of the request message.
 * The `did` attribute is a required string value and denotes DID in use by the responder. Note that this MAY NOT be the same DID used in the invitation.
 * The `did_doc~attach` contains the DID Doc associated with the DID as a [signed attachment](../../concepts/0017-attachments/README.md). If the DID method for the presented DID is not a peer method and the DID Doc is resolvable on a ledger, the `did_doc~attach` attribute is optional.
+  * If the DID and DIDDoc being conveyed is different from that conveyed in the initial contact with the requester, the DIDDoc attachment should be signed by the earlier key. For example, if the requester sent the request to a DID service endpoint from a public DID or an out-of-band invitation, the signature on the DIDDoc should use the key from that interaction.
 
 In addition to a new DID, the associated DID Doc might contain a new endpoint. This new DID and endpoint are to be used going forward in the relationship.
 
@@ -317,7 +330,7 @@ When the message is sent, the _responder_ are now in the `response-sent` state. 
 
 #### Response Processing
 
-When the requester receives the `response` message, they will verify the `change_sig` provided. After validation, they will update their wallet with the new information. If the endpoint was changed, they may wish to execute a Trust Ping to verify that new endpoint.
+When the requester receives the `response` message, they will verify the signature on the DID Doc attachment. After validation, they will update their wallet with the new information, and use that information in sending the `complete` message.
 
 #### Response Errors
 
@@ -361,7 +374,7 @@ After a `complete` message is sent, the *requester* is in the `completed` termin
 
 ## Next Steps
 
-The exchange between the _requester_ and the _responder_ has been completed. This relationship has no trust associated with it. The next step should be the exchange of proofs to build trust sufficient for the purpose of the relationship.
+The exchange between the _requester_ and the _responder_ has been completed. This relationship has no trust associated with it. The next step should be to increase the trust to a sufficient level for the purpose of the relationship, such as through an exchange of proofs.
 
 ## Peer DID Maintenance
 

--- a/features/0023-did-exchange/README.md
+++ b/features/0023-did-exchange/README.md
@@ -130,7 +130,7 @@ The `request` message is used to communicate the DID document of the _requester_
 
 The _requester_ may provision a new DID according to the DID method spec. For a Peer DID, this involves creating a matching peer DID and key. The newly provisioned DID and DID Doc is presented in the `request` message as follows:
 
-#### Example
+### Request Message Example
 
 ```jsonc
 {
@@ -155,7 +155,7 @@ The _requester_ may provision a new DID according to the DID method spec. For a 
 }
 ```
 
-#### Attributes
+#### Request Message Attributes
 
 * The `@type` attribute is a required string value that denotes that the received message is an exchange request.
 * The [`~thread`](../../concepts/0008-message-id-and-threading/README.md#thread-object) decorator MUST be included:
@@ -176,7 +176,7 @@ When a `request` responds to an explicit invitation, its `~thread.pthid` MUST be
 
 When a `request` responds to an implicit invitation, its `~thread.pthid` MUST contain a [DID URL](https://w3c-ccg.github.io/did-spec/#dfn-did-url) that resolves to the specific `service` on a DID document that contains the invitation.
 
-**Example referencing an explicit invitation**
+##### Example Referencing an Explicit Invitation
 
 ```jsonc
 {
@@ -201,7 +201,7 @@ When a `request` responds to an implicit invitation, its `~thread.pthid` MUST co
 }
 ```
 
-**Example referencing an implicit invitation**
+##### Example Referencing an Implicit Invitation
 
 ```jsonc
 {
@@ -238,21 +238,21 @@ The _requester_ is in the `request-sent` state. When received, the _responder_ i
 
 #### Request processing
 
-After receiving the exchange request, the _inviter_ evaluates the provided DID and DID Doc according to the DID Method Spec.
+After receiving the exchange request, the _responder_ evaluates the provided DID and DID Doc according to the DID Method Spec.
 
-The _inviter_ should check the information presented with the keys used in the wire-level message transmission to ensure they match.
+The responder should check the information presented with the keys used in the wire-level message transmission to ensure they match.
 
-The _inviter_ MAY look up the corresponding invitation identified in the request's `~thread.pthid` to determine whether it should accept this exchange request.
+The responder MAY look up the corresponding invitation identified in the request's `~thread.pthid` to determine whether it should accept this exchange request.
 
-If the _inviter_ wishes to continue the exchange, they will persist the received information in their wallet. They will then either update the provisional service information to rotate the key, or provision a new DID entirely. The choice here will depend on the nature of the DID used in the invitation.
+If the responder wishes to continue the exchange, they will persist the received information in their wallet. They will then either update the provisional service information to rotate the key, or provision a new DID entirely. The choice here will depend on the nature of the DID used in the invitation.
 
-The _inviter_ will then craft an exchange response using the newly updated or provisioned information.
+The responder will then craft an exchange response using the newly updated or provisioned information.
 
 #### Request Errors
 
 See [Error Section](#errors) above for message format details.
 
-**request_rejected**
+##### Request Rejected
 
 Possible reasons:
 
@@ -263,7 +263,7 @@ Possible reasons:
 - Unsupported endpoint protocol
 - Missing reference to invitation
 
-**request_processing_error**
+##### Request Processing Error
 
 - unknown processing error
 
@@ -271,7 +271,7 @@ Possible reasons:
 
 The exchange response message is used to complete the exchange. This message is required in the flow, as it updates the provisional information presented in the invitation.
 
-#### Example
+### Response Message Example
 
 ```json
 {
@@ -282,13 +282,17 @@ The exchange response message is used to complete the exchange. This message is 
   },
   "did": "B.did@B:A",
   "did_doc~attach": {
-     "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
-     "jws": {
-        "header": {
-           "kid": "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th"
-        },
-        "protected": "eyJhbGciOiJFZERTQSIsImlhdCI6MTU4Mzg4... (bytes omitted)",
-        "signature": "3dZWsuru7QAVFUCtTd0s7uc1peYEijx4eyt5... (bytes omitted)"
+      "@id": "B.did@B:A",
+      "mime-type": "application/json",
+      "data": {
+         "base64": "eyJ0eXAiOiJKV1Qi... (bytes omitted)",
+         "jws": {
+            "header": {
+               "kid": "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th"
+            },
+            "protected": "eyJhbGciOiJFZERTQSIsImlhdCI6MTU4Mzg4... (bytes omitted)",
+            "signature": "3dZWsuru7QAVFUCtTd0s7uc1peYEijx4eyt5... (bytes omitted)"
+            }
       }
    }
 }
@@ -296,11 +300,11 @@ The exchange response message is used to complete the exchange. This message is 
 
 The key used in the signed attachment must be verified against the invitation's `recipientKeys` for continuity.
 
-#### Attributes
+#### Response Message Attributes
 
 * The `@type` attribute is a required string value that denotes that the received message is an exchange request.
 * The `~thread` block contains a `thid` reference to the `@id` of the request message.
-* The `did` attribute is a required string value and denotes DID in use by the _inviter_. Note that this may not be the same DID used in the invitation.
+* The `did` attribute is a required string value and denotes DID in use by the responder. Note that this MAY NOT be the same DID used in the invitation.
 * The `did_doc~attach` contains the DID Doc associated with the DID as a [signed attachment](../../concepts/0017-attachments/README.md). If the DID method for the presented DID is not a peer method and the DID Doc is resolvable on a ledger, the `did_doc~attach` attribute is optional.
 
 In addition to a new DID, the associated DID Doc might contain a new endpoint. This new DID and endpoint are to be used going forward in the relationship.
@@ -313,13 +317,13 @@ When the message is sent, the _responder_ are now in the `response-sent` state. 
 
 #### Response Processing
 
-When the _invitee_ receives the `response` message, they will verify the `change_sig` provided. After validation, they will update their wallet with the new information. If the endpoint was changed, they may wish to execute a Trust Ping to verify that new endpoint.
+When the requester receives the `response` message, they will verify the `change_sig` provided. After validation, they will update their wallet with the new information. If the endpoint was changed, they may wish to execute a Trust Ping to verify that new endpoint.
 
 #### Response Errors
 
 See [Error Section](#errors) above for message format details.
 
-**response_rejected**
+##### Response Rejected
 
 Possible reasons:
 
@@ -330,7 +334,7 @@ Possible reasons:
 - Unsupported endpoint protocol
 - Invalid Signature
 
-**response_processing_error**
+##### Response Processing Error
 
 - unknown processing error
 
@@ -338,7 +342,7 @@ Possible reasons:
 
 The exchange `complete` message is used to confirm the exchange to the _responder_. This message is **required** in the flow, as it marks the exchange complete. The _responder_ may then invoke any protocols desired based on the context expressed via the `pthid` in the DID Exchange protocol.
 
-#### Example
+### Complete Message Example
 
 ```jsonc
 {
@@ -355,11 +359,11 @@ The `pthid` is required in this message, and must be identical to the `pthid` us
 
 After a `complete` message is sent, the *requester* is in the `completed` terminal state. Receipt of the message puts the *responder* into the `completed` state.
 
-#### Next Steps
+## Next Steps
 
 The exchange between the _requester_ and the _responder_ has been completed. This relationship has no trust associated with it. The next step should be the exchange of proofs to build trust sufficient for the purpose of the relationship.
 
-#### Peer DID Maintenance
+## Peer DID Maintenance
 
 When Peer DIDs are used in an exchange, it is likely that both the _requester_ and _responder_ will want to perform some relationship maintenance such as key rotations. Future RFC updates will add these maintenance features.
 

--- a/features/0023-did-exchange/README.md
+++ b/features/0023-did-exchange/README.md
@@ -372,6 +372,18 @@ The `pthid` is required in this message, and must be identical to the `pthid` us
 
 After a `complete` message is sent, the *requester* is in the `completed` terminal state. Receipt of the message puts the *responder* into the `completed` state.
 
+#### Complete Errors
+
+See [Error Section](#errors) above for message format details.
+
+##### Complete Rejected
+
+This is unlikely to occur with other than an unknown processing error (covered below), so no possible reasons are listed. As experience is gained with the protocol, possible reasons may be added.
+
+##### Complete Processing Error
+
+- unknown processing error
+
 ## Next Steps
 
 The exchange between the _requester_ and the _responder_ has been completed. This relationship has no trust associated with it. The next step should be to increase the trust to a sufficient level for the purpose of the relationship, such as through an exchange of proofs.


### PR DESCRIPTION
Some further cleanup on the DID Exchange RFC.

- Some references to the "inviter" and "invitee" were left from my last clean up `#fail`
- Adjusted the `attach~did-doc` field to match the RFC 0017 Attachments format
- Changed some titles to eliminate some markdown lint complaints because such issues bug me

I think a quick review and merge is likely OK with this one.

This does NOT address #534 but the example attachment change was a result of a comment in that issue.