### PR TITLE
Update formulation, formatting in did-exchange RFC

### DIFF
--- a/features/0023-did-exchange/README.md
+++ b/features/0023-did-exchange/README.md
@@ -122,7 +122,13 @@ No errors are sent in timeout situations. If the _requester_ or _responder_ wish
 
 ## Implicit and Explicit Invitations
 
-The DID Exchange Protocol is preceded by either knowledge of a resolvable DID (an implicit invitation), or by a `out-of-band/%VER/invitation` message from the [Out Of Band Protocols RFC](../0434-outofband/README.md). The information from either the resolved DID Document or the `service` element of the `handshake_protocols` attribute of the `invitation` message is used to construct the `request` message to start the protocol.
+The DID Exchange Protocol is preceded by 
+- either knowledge of a resolvable DID (an implicit invitation) 
+- or by a `out-of-band/%VER/invitation` message from the [Out Of Band Protocols RFC](../0434-outofband/README.md). 
+
+The information needed to construct the `request` message to start the protocol is used
+- either from the resolved DID Document 
+- or the `service` element of the `handshake_protocols` attribute of the `invitation`.
 
 ## 1. Exchange Request
 


### PR DESCRIPTION
3 points I would like to address here

- Changed order of the words a bit
- When there's multiple options (especially "wordy" choices such as in edited example), I would find using list of points more readable than "plain sentence". This would be applicable to more places in this (and probably other documents as well) though.
- An open question, I don't understand this "or the `service` element of the `handshake_protocols` attribute of the `invitation` message is used to". I looked at out of band invitation example https://github.com/hyperledger/aries-rfcs/blob/master/features/0434-outofband/README.md but it's just a list, so I don't understand what's meant by "service` element of the `handshake_protocols`". Can someone clarify?