### PR TITLE
RFC 0593: JSON-LD Credential Attachment format for requesting and presenting credentials

### DIFF
--- a/features/0453-issue-credential-v2/README.md
+++ b/features/0453-issue-credential-v2/README.md
@@ -148,6 +148,7 @@ Credential Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
 DIF Credential Manifest | `dif/credential-manifest@v1.0` | [`propose-credential` attachment format](../0511-dif-cred-manifest-attach/README.md#propose-credential-attachment-format) | 
 Hyperledger Indy Credential Abstract | `hlindy/cred-abstract@v2.0` | [`cred abstract` format](../0592-indy-attachments/README.md#cred-abstract-format)|
+Linked Data Proof VC Proposal  | `aries/ld-proof-vc-proposal@v1.0` | [`ld-proof-vc-proposal` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-proposal-attachment-format) |
 
 #### Offer Credential
 
@@ -198,6 +199,7 @@ Credential Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
 DIF Credential Manifest | `dif/credential-manifest@v1.0` | [`offer-credential` attachment format](../0511-dif-cred-manifest-attach/README.md#offer-credential-attachment-format) | 
 Hyperledger Indy Credential Abstract | `hlindy/cred-abstract@v2.0` | [`cred abstract` format](../0592-indy-attachments/README.md#cred-abstract-format)|
+Linked Data Proof VC Detail  | `aries/ld-proof-vc-detail@v1.0` | [`ld-proof-vc-detail` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-detail-attachment-format) |
 
 #### Request Credential
 
@@ -242,6 +244,7 @@ Credential Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
 DIF Credential Manifest | `dif/credential-manifest@v1.0` | [`request-credential` attachment format](../0511-dif-cred-manifest-attach/README.md#request-credential-attachment-format) | 
 Hyperledger Indy Credential Request | `hlindy/cred-req@v2.0` | [`cred request` format](../0592-indy-attachments/README.md#cred-request-format)|
+Linked Data Proof VC Detail  | `aries/ld-proof-vc-detail@v1.0` | [`ld-proof-vc-detail` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-detail-attachment-format) |
 
 #### Issue Credential
 
@@ -287,6 +290,7 @@ If the issuer wants an acknowledgement that the issued credential was accepted, 
 Credential Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
 Hyperledger Indy Credential | `hlindy/cred@v2.0` | [credendtial format](../0592-indy-attachments/README.md#credential-format)|
+Linked Data Proof VC  | `aries/ld-proof-vc@v1.0` | [`ld-proof-vc` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-attachment-format) |
 
 #### Preview Credential
 

--- a/features/0453-issue-credential-v2/README.md
+++ b/features/0453-issue-credential-v2/README.md
@@ -148,7 +148,7 @@ Credential Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
 DIF Credential Manifest | `dif/credential-manifest@v1.0` | [`propose-credential` attachment format](../0511-dif-cred-manifest-attach/README.md#propose-credential-attachment-format) | 
 Hyperledger Indy Credential Abstract | `hlindy/cred-abstract@v2.0` | [`cred abstract` format](../0592-indy-attachments/README.md#cred-abstract-format)|
-Linked Data Proof VC Proposal  | `aries/ld-proof-vc-proposal@v1.0` | [`ld-proof-vc-proposal` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-proposal-attachment-format) |
+Linked Data Proof VC Detail  | `hlaries/ld-proof-vc-detail@v1.0` | [`ld-proof-vc-detail` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-detail-attachment-format) |
 
 #### Offer Credential
 

--- a/features/0593-json-ld-cred-attach/README.md
+++ b/features/0593-json-ld-cred-attach/README.md
@@ -1,4 +1,4 @@
-# Aries RFC 0593: JSON-LD Credential Attachment format for requesting and presenting credentials
+# Aries RFC 0593: JSON-LD Credential Attachment format for requesting and issuing credentials
 
 - Authors: Timo Glastra (Animo Solutions), George Aristy (SecureKey Technologies)
 - Status: [PROPOSED](/README.md#proposed)

--- a/features/0593-json-ld-cred-attach/README.md
+++ b/features/0593-json-ld-cred-attach/README.md
@@ -12,7 +12,7 @@
 
 This RFC registers an attachment format for use in the [issue-credential V2](../0453-issue-credential-v2/README.md) protocol based on JSON-LD credentials with [Linked Data Proofs](https://w3c-ccg.github.io/ld-proofs/) from the [VC Data Model](https://www.w3.org/TR/vc-data-model/#linked-data-proofs).
 
-It defines a minimal set of parameters needed to create a common understanding of the verifiable credential to issue. It is based on version [1.0 of the Verifiable Credential Data Model](https://www.w3.org/TR/vc-data-model/) which is a W3C recommendation since 19 November 2019.
+It defines a minimal set of parameters needed to create a common understanding of the verifiable credential to issue. It is based on version [1.0 of the Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model/) which is a W3C recommendation since 19 November 2019.
 
 ## Motivation
 
@@ -90,7 +90,7 @@ A complete [`request credential` message form the Issue Credential protocol 2.0]
 }
 ```
 
-- `credential` - Required. Detail of the JSON-LD Credential that will be issued. Properties should align with the [Verifiable Credential Data Model](https://www.w3.org/TR/vc-data-model). The properties listed below are formally supported, but additional properties MAY be included if it conforms with the data model.
+- `credential` - Required. Detail of the JSON-LD Credential that will be issued. Properties should align with the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model). The properties listed below are formally supported, but additional properties MAY be included if it conforms with the data model.
 
   - `@context`
   - `id`
@@ -110,16 +110,16 @@ A complete [`request credential` message form the Issue Credential protocol 2.0]
   - `credentialStatus` - Optional object. The credential status mechanism to use for the credential. Omitting the property indicates the issued credential will not include a credential status.
     - `type` - Required string. Credential status method type to use for the credential. Should match status method registered in the [Verifiable Credential Extension Registry](https://w3c-ccg.github.io/vc-extension-registry/#status-methods)
 
-The format is closely related to the [Verifiable Credential HTTP API](https://w3c-ccg.github.io/vc-http-api/), but diverts on some places. The main differences are:
+The format is closely related to the [Verifiable Credentials HTTP API](https://w3c-ccg.github.io/vc-http-api/), but diverts on some places. The main differences are:
 
-- The types in the VC HTTP API are more restrictive (.e.g. `@context` must be array of strings). This format allows all fields to use the full syntax ass described by the verifiable credential data model.
+- The types in the VC HTTP API are more restrictive (.e.g. `@context` must be array of strings). This format allows all fields to use the full syntax ass described by the verifiable credentials data model.
 - Instead of specifying the exact `verificationMethod`, the `proofType` that will be used for the credential can be specified.
 
 ### `ld-proof-vc` attachment format
 
 Format identifier: `aries/ld-proof-vc@v1.0`
 
-This format is used to transmit a verifiable credential with linked data proof. The contents of the attachment is a standard JSON-LD Verifiable Credential object with linked data proof as defined by the [Verifiable Credential Data Model](https://www.w3.org/TR/vc-data-model) and the [Linked Data Proofs](https://w3c-ccg.github.io/ld-proofs) specification.
+This format is used to transmit a verifiable credential with linked data proof. The contents of the attachment is a standard JSON-LD Verifiable Credential object with linked data proof as defined by the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model) and the [Linked Data Proofs](https://w3c-ccg.github.io/ld-proofs) specification.
 
 The JSON structure might look like this:
 

--- a/features/0593-json-ld-cred-attach/README.md
+++ b/features/0593-json-ld-cred-attach/README.md
@@ -81,7 +81,7 @@ Format identifier: `aries/ld-proof-vc-detail@v1.0`
 
 This format is used to formally offer or request a credential. It should contain the credential as it is going to be issued, omitting properties that are only available after issuance.
 
-```json
+```jsonc
 {
   "@id": "7293daf0-ed47-4295-8cc4-5beb513e500f",
   "@type": "https://didcomm.org/issue-credential/%VER/request-credential",

--- a/features/0593-json-ld-cred-attach/README.md
+++ b/features/0593-json-ld-cred-attach/README.md
@@ -1,0 +1,249 @@
+# Aries RFC 0593: JSON-LD Credential Attachment format for requesting and presenting credentials
+
+- Authors: Timo Glastra (Animo Solutions)
+- Status: [PROPOSED](/README.md#proposed)
+- Since: 2021-02-24
+- Status Note:
+- Supersedes:
+- Start Date: 2021-02-17
+- Tags: [feature](/tags.md#feature), [protocol](/tags.md#protocol), [credentials](/tags.md#credentials), [test-anomaly](/tags.md#test-anomaly)
+
+## Summary
+
+This RFC registers an attachment format for use in the [issue-credential V2](../0453-issue-credential-v2/README.md) protocol based on JSON-LD credentials with [Linked Data Proofs](https://w3c-ccg.github.io/ld-proofs/) from the [VC Data Model](https://www.w3.org/TR/vc-data-model/#linked-data-proofs).
+
+It defines a minimal set of parameters needed to create a common understanding of the verifiable credential to issue.
+
+## Motivation
+
+The Issue Credential protocol needs an attachment format to be able to exchange JSON-LD credentials with Linked Data Proofs. It is desirable to make use of specifications developed in an open standards body, such as the [Credential Manifest](https://identity.foundation/credential-manifest/) for which the attachment format is described in [RFC 0511: Credential-Manifest Attachment format](../0511-dif-cred-manifest-attach/README.md). However, the _Credential Manifest_ is not finished and ready yet, and therefore there is a need to bridge the gap between standards.
+
+## Tutorial
+
+Complete examples of messages are provided in the [reference section](#reference).
+
+## Reference
+
+### `propose-credential` attachment format
+
+Format identifier: `aries/vc-ld-proof@v1.0`
+
+Complete message example:
+
+```json
+{
+  "@id": "64f6518b-fede-43a7-ba45-4ba7e7af0e7b",
+  "@type": "https://didcomm.org/issue-credential/%VER/propose-credential",
+  "comment": "<some comment>",
+  "formats": [
+    {
+      "attach_id": "64a11985-79a9-4daa-b0e3-0ae0531e7a14",
+      "format": "aries/vc-ld-proof@v1.0"
+    }
+  ],
+  "filter~attach": [
+    {
+      "@id": "64a11985-79a9-4daa-b0e3-0ae0531e7a14",
+      "mime-type": "application/json",
+      "data": {
+        "json": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://www.w3.org/2018/credentials/examples/v1"
+          ],
+          "type": ["VerifiableCredential", "AlumniCredential"],
+          "issuer": "did:key:z6MkodKV3mnjQQMB9jhMZtKD9Sm75ajiYq51JDLuRSPZTXrr",
+          "credentialStatusType": ["CredentialStatusList2017"],
+          "credentialSchema": {
+            "id": "https://example.org/examples/degree.json",
+            "type": "JsonSchemaValidator2018"
+          },
+          "proofType": ["Ed25519Signature2018", "BbsBlsSignature2020"]
+        }
+      }
+    }
+  ]
+}
+```
+
+Description of fields:
+
+- `@context` -- An optional array of contexts indicating the contexts proposed by the holder to use for the credential. See [Contexts](https://www.w3.org/TR/vc-data-model/#contexts). The first context MUST always be `"https://www.w3.org/2018/credentials/v1"` per the VC data model.
+- `type` -- An optional array of types indicating the types proposed by the holder to use for the credential. See [Types](https://www.w3.org/TR/vc-data-model/#types). The array MUST always contain `"VerifiableCredential"` per the VC data model.
+- `issuer` -- An optional URI indicating the issuer id proposed by the holder to use for the credential. See [Issuer](https://www.w3.org/TR/vc-data-model/#issuer). Only the issuer URI (id) is supported at the moment.
+- `credentialStatusType` -- An optional array of strings that indicates the credential status types the holder is willing to accept. See [Status](https://www.w3.org/TR/vc-data-model/#status). If no `credentialStatusType` is present it means no preference on the credential status mechanism is given by the holder. However, an empty array indicates the holder proposes a credential without credential status, i.e. the credential is not revocable.
+- `credentialSchema` -- An optional object indicating the proposed schema to use for the credential. It matches the `credentialSchema` from [Data Schemas](https://www.w3.org/TR/vc-data-model/#data-schemas).
+- `proofType` -- An optional array of strings indicating the proof types the holder is willing to accept. Entries match the `type` property of the [Proofs](https://www.w3.org/TR/vc-data-model/#proofs-signatures) object.
+
+### `offer-credential` attachment format
+
+Format identifier: `aries/vc-ld-proof@v1.0`
+
+Complete message example:
+
+```jsonc
+{
+  "@id": "2570ed16-91e7-49e7-bc61-b562d1ac2f18",
+  "@type": "https://didcomm.org/issue-credential/%VER/offer-credential",
+  "comment": "<some comment>",
+  "formats": [
+    {
+      "attach_id": "d60c05ac-35c2-484c-af3e-8ef7f21baf0a",
+      "format": "aries/vc-ld-proof@v1.0"
+    }
+  ],
+  "offers~attach": [
+    {
+      "@id": "d60c05ac-35c2-484c-af3e-8ef7f21baf0a",
+      "mime-type": "application/json",
+      "data": {
+        "json": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://www.w3.org/2018/credentials/examples/v1"
+          ],
+          "type": ["VerifiableCredential", "AlumniCredential"],
+          "issuer": "did:key:z6MkodKV3mnjQQMB9jhMZtKD9Sm75ajiYq51JDLuRSPZTXrr",
+          "credentialStatusType": "CredentialStatusList2017",
+          "credentialSchema": {
+            "id": "https://example.org/examples/degree.json",
+            "type": "JsonSchemaValidator2018"
+          },
+          "proofType": ["Ed25519Signature2018", "BbsBlsSignature2020"]
+        }
+      }
+    }
+  ]
+}
+```
+
+Description of fields:
+
+- `@context` -- An array of contexts indicating the contexts the issuer will use for the credential. See [Contexts](https://www.w3.org/TR/vc-data-model/#contexts). The first context MUST always be `"https://www.w3.org/2018/credentials/v1"` per the VC data model.
+- `type` -- An array of types indicating the types the issuer will use for the credential. See [Types](https://www.w3.org/TR/vc-data-model/#types). The array MUST always contain `"VerifiableCredential"` per the VC data model.
+- `issuer` -- An URI indicating the issuer id the issuer will use for the credential. See [Issuer](https://www.w3.org/TR/vc-data-model/#issuer). Only the issuer URI (id) is supported at the moment.
+- `credentialStatusType` -- An optional string that indicates the credential status type the issuer will use for the credential. See [Status](https://www.w3.org/TR/vc-data-model/#status). If no `credentialStatusType` is present it means no `credentialStatus` will be included in the credential, i.e. the credential is not revocable.
+- `credentialSchema` -- An optional object indicating the proposed schema to use for the credential. It matches the `credentialSchema` from [Data Schemas](https://www.w3.org/TR/vc-data-model/#data-schemas). If no `credentialSchema` is present it means no `credentialSchema` will be included in the credential.
+- `proofType` -- An array of strings indicating the proof types the issuer will use for the credential. Entries match the `type` property of the [Proofs](https://www.w3.org/TR/vc-data-model/#proofs-signatures) object. Multiple entries indicate the issuer will attach multiple proofs to the credential.
+
+### `request-credential` attachment format
+
+Format identifier: `aries/vc-ld-proof@v1.0`
+
+```json
+{
+  "@id": "7293daf0-ed47-4295-8cc4-5beb513e500f",
+  "@type": "https://didcomm.org/issue-credential/%VER/request-credential",
+  "comment": "<some comment>",
+  "formats": [
+    {
+      "attach_id": "13a3f100-38ce-4e96-96b4-ea8f30250df9",
+      "format": "aries/vc-ld-proof@v1.0"
+    }
+  ],
+  "requests~attach": [
+    {
+      "@id": "13a3f100-38ce-4e96-96b4-ea8f30250df9",
+      "mime-type": "application/json",
+      "data": {
+        "json": {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://www.w3.org/2018/credentials/examples/v1"
+          ],
+          "type": ["VerifiableCredential", "AlumniCredential"],
+          "issuer": "did:key:z6MkodKV3mnjQQMB9jhMZtKD9Sm75ajiYq51JDLuRSPZTXrr",
+          "credentialStatusType": "CredentialStatusList2017",
+          "credentialSchema": {
+            "id": "https://example.org/examples/degree.json",
+            "type": "JsonSchemaValidator2018"
+          },
+          "proofType": ["Ed25519Signature2018", "BbsBlsSignature2020"]
+        }
+      }
+    }
+  ]
+}
+```
+
+Description of fields:
+
+- `@context` -- An array of contexts indicating the contexts the holder requests for the credential. See [Contexts](https://www.w3.org/TR/vc-data-model/#contexts). The first context MUST always be `"https://www.w3.org/2018/credentials/v1"` per the VC data model.
+- `type` -- An array of types indicating the types the holder requests for the credential. See [Types](https://www.w3.org/TR/vc-data-model/#types). The array MUST always contain `"VerifiableCredential"` per the VC data model.
+- `issuer` -- An URI indicating the issuer id the holder requests for the credential. See [Issuer](https://www.w3.org/TR/vc-data-model/#issuer). Only the issuer URI (id) is supported at the moment.
+- `credentialStatusType` -- An optional string that indicates the credential status type holder requests for the credential. It must match the value of `credentialStatus.type` in the issued credential. See [Status](https://www.w3.org/TR/vc-data-model/#status). If no `credentialStatusType` is present it means no `credentialStatus` will be included in the credential, i.e. the credential is not revocable.
+- `credentialSchema` -- An optional object indicating the requested schema to use for the credential. It matches the `credentialSchema` from [Data Schemas](https://www.w3.org/TR/vc-data-model/#data-schemas). If no `credentialSchema` is present it means no `credentialSchema` will be included in the credential.
+- `proofType` -- An array of strings indicating the proof types the holder requests for the credential. Entries match the `type` property of the [Proofs](https://www.w3.org/TR/vc-data-model/#proofs-signatures) object. Multiple entries indicate the holder requests multiple proofs for the credential.
+
+### `issue-credential` attachment format
+
+Format identifier: `aries/vc-ld-proof@v1.0`
+
+The contents of the attachment is a standard JSON-LD Verifiable Credential object with linked data proof.
+
+```json
+{
+  "@id": "284d3996-ba85-45d9-964b-9fd5805517b6",
+  "@type": "https://didcomm.org/issue-credential/%VER/issue-credential",
+  "comment": "<some comment>",
+  "formats": [
+    {
+      "attach_id": "5b38af88-d36f-4f77-bb7a-2f04ab806eb8",
+      "format": "aries/vc-ld-proof@v1.0"
+    }
+  ],
+  "requests~attach": [
+    {
+      "@id": "5b38af88-d36f-4f77-bb7a-2f04ab806eb8",
+      "mime-type": "application/json+ld",
+      "data": {
+        "json": {
+          "@context": "https://www.w3.org/2018/credentials/v1",
+          "id": "https://eu.com/claims/DriversLicense",
+          "type": ["EUDriversLicense"],
+          "issuer": "did:foo:123",
+          "issuanceDate": "2010-01-01T19:73:24Z",
+          "credentialSubject": {
+            "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+            "license": {
+              "number": "34DGE352",
+              "dob": "07/13/80"
+            }
+          },
+          "proof": {
+            "type": "RsaSignature2018",
+            "created": "2017-06-18T21:19:10Z",
+            "proofPurpose": "assertionMethod",
+            "verificationMethod": "https://example.edu/issuers/keys/1",
+            "jws": "..."
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+## Drawbacks
+
+N/A
+
+## Rationale and alternatives
+
+- The `hlindy-zkp-v1.0` format is an alternative restricted to the Hyperledger Indy network. The `dif/credential-manifest@v1.0` allows to issue JSON-LD credentials but is not ready yet for usage.
+
+## Prior art
+
+N/A
+
+## Unresolved questions
+
+N/A
+
+## Implementations
+
+The following lists the implementations (if any) of this RFC. Please do a pull request to add your implementation. If the implementation is open source, include a link to the repo or to the implementation within the repo. Please be consistent in the "Name" field so that a mechanical processing of the RFCs can generate a list of all RFCs supported by an Aries implementation.
+
+| Name / Link | Implementation Notes |
+| ----------- | -------------------- |
+|             |

--- a/features/0593-json-ld-cred-attach/README.md
+++ b/features/0593-json-ld-cred-attach/README.md
@@ -75,7 +75,7 @@ A complete [`request credential` message form the Issue Credential protocol 2.0]
   "formats": [
     {
       "attach_id": "13a3f100-38ce-4e96-96b4-ea8f30250df9",
-      "format": "aries/vc-ld-proof-req@v1.0"
+      "format": "aries/ld-proof-vc-detail@v1.0"
     }
   ],
   "requests~attach": [
@@ -90,7 +90,7 @@ A complete [`request credential` message form the Issue Credential protocol 2.0]
 }
 ```
 
-- `credential` - Required. Detail of the JSON-LD Credential that will be issued. Properties should align with the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model). The properties listed below are formally supported, but additional properties MAY be included if it conforms with the data model.
+- `credential` - Required. Detail of the JSON-LD Credential that will be issued. Properties MUST align with the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model). This also means all properties required by the data model MUST be present. The properties listed below are formally supported, but additional properties MAY be included if it conforms with the data model.
 
   - `@context`
   - `id`
@@ -162,7 +162,7 @@ A complete [`issue-credential` message form the Issue Credential protocol 2.0](.
   "formats": [
     {
       "attach_id": "5b38af88-d36f-4f77-bb7a-2f04ab806eb8",
-      "format": "aries/vc-ld-proof@v1.0"
+      "format": "aries/ld-proof-vc@v1.0"
     }
   ],
   "credentials~attach": [

--- a/features/0593-json-ld-cred-attach/README.md
+++ b/features/0593-json-ld-cred-attach/README.md
@@ -81,7 +81,7 @@ A complete [`request credential` message form the Issue Credential protocol 2.0]
   "requests~attach": [
     {
       "@id": "13a3f100-38ce-4e96-96b4-ea8f30250df9",
-      "mime-type": "application/ld+json",
+      "mime-type": "application/json",
       "data": {
         "base64": "ewogICJjcmVkZW50aWFsIjogewogICAgIkBjb250...(clipped)...IkVkMjU1MTlTaWduYXR1cmUyMDE4IgogIH0KfQ=="
       }
@@ -105,7 +105,7 @@ A complete [`request credential` message form the Issue Credential protocol 2.0]
   - `proofType` - Required string. The proof type used for the proof. Should match suites registered in the [Linked Data Cryptographic Suite Registry](https://w3c-ccg.github.io/ld-cryptosuite-registry/#signature-suites).
   - `proofPurpose` - Optional string, default `assertionMethod`. The proof purpose used for the proof. Should match proof purposes registered in the [Linked Data Proofs Specification](https://w3c-ccg.github.io/ld-proofs/#proof-purpose).
   - `created` - Optional string, default current system time. The date and time of the proof (with a maximum accuracy in seconds).
-  - `challenge` - Optional string. A challenge to include in the proof. SHOUlD be provided by the requesting party of the credential (=holder).
+  - `challenge` - Optional string. A challenge to include in the proof. SHOULD be provided by the requesting party of the credential (=holder).
   - `domain` - Optional string. The intended domain of validity for the proof.
   - `credentialStatus` - Optional object. The credential status mechanism to use for the credential. Omitting the property indicates the issued credential will not include a credential status.
     - `type` - Required string. Credential status method type to use for the credential. Should match status method registered in the [Verifiable Credential Extension Registry](https://w3c-ccg.github.io/vc-extension-registry/#status-methods)

--- a/features/0593-json-ld-cred-attach/README.md
+++ b/features/0593-json-ld-cred-attach/README.md
@@ -2,7 +2,7 @@
 
 - Authors: Timo Glastra (Animo Solutions), George Aristy (SecureKey Technologies)
 - Status: [PROPOSED](/README.md#proposed)
-- Since: 2021-02-24
+- Since: 2021-03-16
 - Status Note:
 - Supersedes:
 - Start Date: 2021-02-17
@@ -12,7 +12,7 @@
 
 This RFC registers an attachment format for use in the [issue-credential V2](../0453-issue-credential-v2/README.md) protocol based on JSON-LD credentials with [Linked Data Proofs](https://w3c-ccg.github.io/ld-proofs/) from the [VC Data Model](https://www.w3.org/TR/vc-data-model/#linked-data-proofs).
 
-It defines a minimal set of parameters needed to create a common understanding of the verifiable credential to issue. It is based on version [1.0 of the Data Model](https://www.w3.org/TR/vc-data-model/) which is a W3C recommendation since 19 November 2019.
+It defines a minimal set of parameters needed to create a common understanding of the verifiable credential to issue. It is based on version [1.0 of the Verifiable Credential Data Model](https://www.w3.org/TR/vc-data-model/) which is a W3C recommendation since 19 November 2019.
 
 ## Motivation
 
@@ -24,79 +24,48 @@ Complete examples of messages are provided in the [reference section](#reference
 
 ## Reference
 
-### `ld-proof-vc-proposal` attachment format
-
-Format identifier: `aries/ld-proof-vc-proposal@v1.0`
-
-The credential proposal allows the holder to initiate a credential exchange without fully specifying the contents of the credential. If all properties of the credential are already known, the protocol can also be initiated with a credential request. While the credential detail requires all fields to be present, the proposal allows for fields to be omitted.
-
-The below `propose-credential` message shows an example of an credential proposal with the `@context`, `type`, `credentialSubject` and `options.credentialStatus` present. The issuer can then send a credential detail in an `offer-credential` message adding extra properties required for issuance such as `issuer` and `options.proofType`.
-
-```json
-{
-  "@id": "257363ab-a3f9-4bba-ad3f-9f69501135f5",
-  "@type": "https://didcomm.org/issue-credential/%VER/propose-credential",
-  "comment": "<some comment>",
-  "formats": [
-    {
-      "attach_id": "35054fa5-112e-4ef7-93ab-7778f59eb4e3",
-      "format": "aries/vc-ld-proof@v1.0"
-    }
-  ],
-  "filter~attach": [
-    {
-      "@id": "35054fa5-112e-4ef7-93ab-7778f59eb4e3",
-      "mime-type": "application/ld+json",
-      "data": {
-        "json": {
-          "credential": {
-            "@context": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://www.w3.org/2018/credentials/examples/v1"
-            ],
-            "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-            "credentialSubject": {
-              "id": "did:key:z6MkodKV3mnjQQMB9jhMZtKD9Sm75ajiYq51JDLuRSPZTXrr",
-              "degree": {
-                "type": "BachelorDegree",
-                "name": "Bachelor of Science and Arts"
-              }
-            }
-          },
-          "options": {
-            "credentialStatus": {
-              "type": "CredentialStatusList2017"
-            }
-          }
-        }
-      }
-    }
-  ]
-}
-```
-
-- `credential` - Required. JSON-LD Credential as proposed by the holder. Properties should align with the criteria described in the [Verifiable Credential Data Model](https://www.w3.org/TR/vc-data-model). The properties listed below are formally supported, but additional properties MAY be included if it conforms with the data model. A note indicates the property deviates from the criteria as defined by the data model.
-
-  - `@context`
-  - `type`
-  - `id`
-  - `issuer` - Optional
-  - `issuanceDate` - Optional
-  - `expirationDate`
-  - `credentialSubject` - Optional. Allows the holder to propose a credential without specifying the claims.
-  - `credentialSchema`
-
-- `options` - Additional options for the credential.
-
-  - `proofType` - Optional list of proof types proposed by the holder to use for the linked data proof. Entries should match suites registered in the [Linked Data Cryptographic Suite Registry](https://w3c-ccg.github.io/ld-cryptosuite-registry/).
-  - `credentialStatus` - Optional object defining the credential status mechanism proposed by the holder to use for the credential. MAY contain additional properties if required for the status method.
-    - `type` - Credential status type proposed by the holder to use for the credential. Required if `credentialStatus` object is present.
-
 ### `ld-proof-vc-detail` attachment format
 
 Format identifier: `aries/ld-proof-vc-detail@v1.0`
 
-This format is used to formally offer or request a credential. It should contain the credential as it is going to be issued, omitting properties that are only available after issuance.
+This format is used to formally propose, offer, or request a credential. The `credential` property should contain the credential as it is going to be issued, without the `proof` and `credentialStatus` properties. Options for these properties are specified in the `options` object.
+
+The JSON structure might look like this:
+
+```json
+{
+  "credential": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
+    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+    "issuer": "did:key:z6MkodKV3mnjQQMB9jhMZtKD9Sm75ajiYq51JDLuRSPZTXrr",
+    "issuanceDate": "2020-01-01T19:23:24Z",
+    "expirationDate": "2021-01-01T19:23:24Z",
+    "credentialSubject": {
+      "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science and Arts"
+      }
+    }
+  },
+  "options": {
+    "proofPurpose": "assertionMethod",
+    "created": "2020-04-02T18:48:36Z",
+    "domain": "example.com",
+    "challenge": "9450a9c1-4db5-4ab9-bc0c-b7a9b2edac38",
+    "credentialStatus": {
+      "type": "CredentialStatusList2017"
+    },
+    "proofType": "Ed25519Signature2018"
+  }
+}
+```
+
+A complete [`request credential` message form the Issue Credential protocol 2.0](../0453-issue-credential-v2/README.md#request-credential) might look like this:
 
 ```jsonc
 {
@@ -114,59 +83,76 @@ This format is used to formally offer or request a credential. It should contain
       "@id": "13a3f100-38ce-4e96-96b4-ea8f30250df9",
       "mime-type": "application/ld+json",
       "data": {
-        "json": {
-          "credential": {
-            "@context": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://www.w3.org/2018/credentials/examples/v1"
-            ],
-            "type": ["VerifiableCredential", "AlumniCredential"],
-            "credentialSubject": {
-              "id": "did:key:z6MkodKV3mnjQQMB9jhMZtKD9Sm75ajiYq51JDLuRSPZTXrr",
-              "degree": {
-                "type": "BachelorDegree",
-                "name": "Bachelor of Science and Arts"
-              }
-            },
-            "issuer": "did:key:z6MkodKV3mnjQQMB9jhMZtKD9Sm75ajiYq51JDLuRSPZTXrr",
-            "issuanceDate": "2020-01-01T19:23:24Z",
-            "expirationDate": "2021-01-01T19:23:24Z"
-          },
-          "options": {
-            "credentialStatus": {
-              "type": "CredentialStatusList2017"
-            },
-            "proofType": ["Ed25519Signature2018", "BbsBlsSignature2020"]
-          }
-        }
+        "base64": "ewogICJjcmVkZW50aWFsIjogewogICAgIkBjb250...(clipped)...IkVkMjU1MTlTaWduYXR1cmUyMDE4IgogIH0KfQ=="
       }
     }
   ]
 }
 ```
 
-- `credential` - Required. Detail of the JSON-LD Credential that will be issued. Properties should align with the criteria described in the [Verifiable Credential Data Model](https://www.w3.org/TR/vc-data-model). The properties listed below are formally supported, but additional properties MAY be included if it conforms with the data model. A note indicates the property deviates from the criteria as defined by the data model.
+- `credential` - Required. Detail of the JSON-LD Credential that will be issued. Properties should align with the [Verifiable Credential Data Model](https://www.w3.org/TR/vc-data-model). The properties listed below are formally supported, but additional properties MAY be included if it conforms with the data model.
 
   - `@context`
-  - `type`
   - `id`
+  - `type`
   - `issuer`
-  - `issuanceDate` - Optional. If specified the value from the credential detail must be used for the issued credential. If omitted the value will be set at time of issuance
+  - `issuanceDate`
   - `expirationDate`
   - `credentialSubject`
-  - `credentialSchema`
 
-- `options` - Required object defining additional options on how the credential is created.
+- `options` - Required. Options for specifying how the linked data proof is created.
 
-  - `proofType` - Required list of proof types indicating the proof types to use for the linked data proof. Entries should match suites registered in the [Linked Data Cryptographic Suite Registry](https://w3c-ccg.github.io/ld-cryptosuite-registry/). Multiple entries indicate that the credential will contain multiple proofs.
-  - `credentialStatus` - Optional object defining the credential status mechanism to use for the credential. MAY contain additional properties if required for the status method. Omitting the property indicates the issued credential will not include a credential status.
-    - `type` - Credential status method type to use for the credential. Required if `credentialStatus` object is present.
+  - `proofType` - Required string. The proof type used for the proof. Should match suites registered in the [Linked Data Cryptographic Suite Registry](https://w3c-ccg.github.io/ld-cryptosuite-registry/#signature-suites).
+  - `proofPurpose` - Optional string, default `assertionMethod`. The proof purpose used for the proof. Should match proof purposes registered in the [Linked Data Proofs Specification](https://w3c-ccg.github.io/ld-proofs/#proof-purpose).
+  - `created` - Optional string, default current system time. The date and time of the proof (with a maximum accuracy in seconds).
+  - `challenge` - Optional string. A challenge to include in the proof. SHOUlD be provided by the requesting party of the credential (=holder).
+  - `domain` - Optional string. The intended domain of validity for the proof.
+  - `credentialStatus` - Optional object. The credential status mechanism to use for the credential. Omitting the property indicates the issued credential will not include a credential status.
+    - `type` - Required string. Credential status method type to use for the credential. Should match status method registered in the [Verifiable Credential Extension Registry](https://w3c-ccg.github.io/vc-extension-registry/#status-methods)
+
+The format is closely related to the [Verifiable Credential HTTP API](https://w3c-ccg.github.io/vc-http-api/), but diverts on some places. The main differences are:
+
+- The types in the VC HTTP API are more restrictive (.e.g. `@context` must be array of strings). This format allows all fields to use the full syntax ass described by the verifiable credential data model.
+- Instead of specifying the exact `verificationMethod`, the `proofType` that will be used for the credential can be specified.
 
 ### `ld-proof-vc` attachment format
 
 Format identifier: `aries/ld-proof-vc@v1.0`
 
 This format is used to transmit a verifiable credential with linked data proof. The contents of the attachment is a standard JSON-LD Verifiable Credential object with linked data proof as defined by the [Verifiable Credential Data Model](https://www.w3.org/TR/vc-data-model) and the [Linked Data Proofs](https://w3c-ccg.github.io/ld-proofs) specification.
+
+The JSON structure might look like this:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "id": "http://example.gov/credentials/3732",
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": {
+    "id": "did:web:vc.transmute.world"
+  },
+  "issuanceDate": "2020-03-10T04:24:12.164Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    }
+  },
+  "proof": {
+    "type": "JsonWebSignature2020",
+    "created": "2020-03-21T17:51:48Z",
+    "verificationMethod": "did:web:vc.transmute.world#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
+    "proofPurpose": "assertionMethod",
+    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSJ9..OPxskX37SK0FhmYygDk-S4csY_gNhCUgSOAaXFXDTZx86CmI5nU9xkqtLWg-f4cqkigKDdMVdtIqWAvaYx2JBA"
+  }
+}
+```
+
+A complete [`issue-credential` message form the Issue Credential protocol 2.0](../0453-issue-credential-v2/README.md#issue-credential) might look like this:
 
 ```json
 {
@@ -179,37 +165,12 @@ This format is used to transmit a verifiable credential with linked data proof. 
       "format": "aries/vc-ld-proof@v1.0"
     }
   ],
-  "requests~attach": [
+  "credentials~attach": [
     {
       "@id": "5b38af88-d36f-4f77-bb7a-2f04ab806eb8",
       "mime-type": "application/ld+json",
       "data": {
-        "json": {
-          "@context": [
-            "https://www.w3.org/2018/credentials/v1",
-            "https://www.w3.org/2018/credentials/examples/v1"
-          ],
-          "id": "http://example.gov/credentials/3732",
-          "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-          "issuer": {
-            "id": "did:web:vc.transmute.world"
-          },
-          "issuanceDate": "2020-03-10T04:24:12.164Z",
-          "credentialSubject": {
-            "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-            "degree": {
-              "type": "BachelorDegree",
-              "name": "Bachelor of Science and Arts"
-            }
-          },
-          "proof": {
-            "type": "JsonWebSignature2020",
-            "created": "2020-03-21T17:51:48Z",
-            "verificationMethod": "did:web:vc.transmute.world#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
-            "proofPurpose": "assertionMethod",
-            "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSJ9..OPxskX37SK0FhmYygDk-S4csY_gNhCUgSOAaXFXDTZx86CmI5nU9xkqtLWg-f4cqkigKDdMVdtIqWAvaYx2JBA"
-          }
-        }
+        "base64": "ewogICAgICAgICAgIkBjb250ZXogWwogICAgICAg...(clipped)...RNVmR0SXFXZhWXgySkJBIgAgfQogICAgICAgIH0="
       }
     }
   ]

--- a/index.md
+++ b/index.md
@@ -108,6 +108,7 @@
 * [0566: Issuer-Hosted Custodial Agents](concepts/0566-issuer-hosted-custodidal-agents/README.md) (2020-11-16 &mdash; [`concept`](/tags.md#concept))
 * [0587: Encryption Envelope v2](features/0587-encryption-envelope-v2/README.md) (2021-02-10 &mdash; [`feature`](/tags.md#feature))
 * [0592: Indy Attachment Formats for Requesting and Presenting Credentials](features/0592-indy-attachments/README.md) (2021-02-23 &mdash; [`feature`](/tags.md#feature) [`protocol`](/tags.md#protocol) [`credentials`](/tags.md#credentials) [`test-anomaly`](/tags.md#test-anomaly))
+* [0593: JSON-LD Credential Attachment format for requesting and presenting credentials](features/0593-json-ld-cred-attach/README.md) (2021-02-24 &mdash; [`feature`](/tags.md#feature) [`protocol`](/tags.md#protocol) [`credentials`](/tags.md#credentials) [`test-anomaly`](/tags.md#test-anomaly))
 
 ## [RETIRED](README.md#retired)
 * [0234: Signature Decorator](features/0234-signature-decorator/README.md) (2020-10-14, [3 impls](features/0234-signature-decorator/README.md#implementations) &mdash; [`feature`](/tags.md#feature) [`decorator`](/tags.md#decorator))

--- a/index.md
+++ b/index.md
@@ -108,7 +108,7 @@
 * [0566: Issuer-Hosted Custodial Agents](concepts/0566-issuer-hosted-custodidal-agents/README.md) (2020-11-16 &mdash; [`concept`](/tags.md#concept))
 * [0587: Encryption Envelope v2](features/0587-encryption-envelope-v2/README.md) (2021-02-10 &mdash; [`feature`](/tags.md#feature))
 * [0592: Indy Attachment Formats for Requesting and Presenting Credentials](features/0592-indy-attachments/README.md) (2021-02-23 &mdash; [`feature`](/tags.md#feature) [`protocol`](/tags.md#protocol) [`credentials`](/tags.md#credentials) [`test-anomaly`](/tags.md#test-anomaly))
-* [0593: JSON-LD Credential Attachment format for requesting and presenting credentials](features/0593-json-ld-cred-attach/README.md) (2021-02-24 &mdash; [`feature`](/tags.md#feature) [`protocol`](/tags.md#protocol) [`credentials`](/tags.md#credentials) [`test-anomaly`](/tags.md#test-anomaly))
+* [0593: JSON-LD Credential Attachment format for requesting and issuing credentials](features/0593-json-ld-cred-attach/README.md) (2021-03-16 &mdash; [`feature`](/tags.md#feature) [`protocol`](/tags.md#protocol) [`credentials`](/tags.md#credentials) [`test-anomaly`](/tags.md#test-anomaly))
 
 ## [RETIRED](README.md#retired)
 * [0234: Signature Decorator](features/0234-signature-decorator/README.md) (2020-10-14, [3 impls](features/0234-signature-decorator/README.md#implementations) &mdash; [`feature`](/tags.md#feature) [`decorator`](/tags.md#decorator))


### PR DESCRIPTION
Still needs some touch-ups, but the general flow is worked out. 

I think we also need to add an `subjectId` property, but still thinking of the implications of how it should be authentically bound to the subject / the didcomm connection