### PR TITLE
Goal codes in credential exchange protocols

### DIFF
--- a/features/0453-issue-credential-v2/README.md
+++ b/features/0453-issue-credential-v2/README.md
@@ -35,6 +35,10 @@ There are two roles in this protocol: Issuer and Holder. Technically, the latter
 
 >Note: When a holder of credentials turns around and uses those credentials to prove something, they become a Prover. In the sister RFC to this one, [0454: Present Proof Protocol 2.0](../0454-present-proof-v2/README.md), the Holder is therefore renamed to Prover. Sometimes in casual conversation, the Holder role here might be called "Prover" as well, but more formally, "Holder" is the right term at this phase of the credential lifecycle.
 
+### Goals
+
+When the goals of each role are not available because of context, goal codes may be specifically included in protocol messages. This is particularly helpful to differentiate between credentials passed between the same parties for several different reasons. A goal code included should be considered to apply to the entire thread and is not necessary to be repeated on each message. Changing the goal code may be done by including the new code in a message. All goal codes are optional, and without default. 
+
 ### States
 
 The choreography diagram [below](#choreography-diagram) details how state evolves in this protocol, in a "happy path." The states include
@@ -115,6 +119,7 @@ Message format:
 {
     "@type": "https://didcomm.org/issue-credential/%VER/propose-credential",
     "@id": "<uuid of propose-message>",
+    "goal_code": "<goal-code>",
     "comment": "<some comment>",
     "credential_preview": <json-ld object>,
     "formats" : [
@@ -137,6 +142,7 @@ Message format:
 
 Description of attributes:
 
+* `goal_code` -- optional field that indicates the goal of the message sender. 
 * `comment` -- an optional field that provides human readable information about this Credential Proposal, so the proposal can be evaluated by human judgment. Follows [DIDComm conventions for l10n](../0043-l10n/README.md).
 * `credential_preview` -- an optional JSON-LD object that represents the credential data that Prover wants to receive. It matches the schema of [Credential Preview](#preview-credential).
 * `formats` -- contains an entry for each `filters~attach` array entry, providing the the value of the attachment `@id` and the verifiable credential format and version of the attachment. Accepted values for the `format` items are provided in the per format "Attachment" sections immediately below.
@@ -159,6 +165,7 @@ Message Format:
 {
     "@type": "https://didcomm.org/issue-credential/%VER/offer-credential",
     "@id": "<uuid of offer message>",
+    "goal_code": "<goal-code>",
     "replacement_id": "<issuer unique id>",
     "comment": "<some comment>",
     "credential_preview": <json-ld object>,
@@ -182,6 +189,7 @@ Message Format:
 
 Description of fields:
 
+* `goal_code` -- optional field that indicates the goal of the message sender. 
 * `replacement_id` -- an optional field to help coordinate credential replacement. When this is present and matches the `replacement_id` of a previously issued credential, it may be used to inform the recipient that the offered credential is considered to be a replacement to the previous credential. This value is unique to the issuer. It must not be used in a credential presentation.
 * `comment` -- an optional field that provides human readable information about this Credential Offer, so the offer can be evaluated by human judgment. Follows [DIDComm conventions for l10n](../0043-l10n/README.md).
 * `credential_preview` -- a JSON-LD object that represents the credential data that Issuer is willing to issue. It matches the schema of [Credential Preview](#preview-credential);
@@ -209,6 +217,7 @@ Message Format:
 {
     "@type": "https://didcomm.org/issue-credential/%VER/request-credential",
     "@id": "<uuid of request message>",
+    "goal_code": "<goal-code>",
     "comment": "<some comment>",
     "formats" : [
         {
@@ -230,6 +239,7 @@ Message Format:
 
 Description of Fields:
 
+* `goal_code` -- optional field that indicates the goal of the message sender. 
 * `comment` -- an optional field that provides human readable information about this Credential Request, so it can be evaluated by human judgment. Follows [DIDComm conventions for l10n](../0043-l10n/README.md).
 * `formats` -- contains an entry for each `requests~attach` array entry, providing the the value of the attachment `@id` and the verifiable credential format and version of the attachment. Accepted values for the `format` items are provided in the per format "Attachment" sections immediately below.
 * `requests~attach` -- an array of [attachments](../../concepts/0017-attachments/README.md) defining the requested formats for the credential.
@@ -253,6 +263,7 @@ Message Format:
 {
     "@type": "https://didcomm.org/issue-credential/%VER/issue-credential",
     "@id": "<uuid of issue message>",
+    "goal_code": "<goal-code>",
     "replacement_id": "<issuer unique id>",
     "comment": "<some comment>",
     "formats" : [

--- a/features/0454-present-proof-v2/README.md
+++ b/features/0454-present-proof-v2/README.md
@@ -45,6 +45,10 @@ Diagrams in this protocol were made in draw.io. To make changes:
 
 The roles are `verifier` and `prover`.  The `verifier` requests the presentation of a proof and verifies the presentation, while the `prover` prepares the proof and presents it to the verifier. Optionally, although unlikely from a business sense, the `prover` may initiate an instance of the protocol using the `propose-presentation` message.
 
+### Goals
+
+When the goals of each role are not available because of context, goal codes may be specifically included in protocol messages. This is particularly helpful to differentiate between credentials passed between the same parties for several different reasons. A goal code included should be considered to apply to the entire thread and is not necessary to be repeated on each message. Changing the goal code may be done by including the new code in a message. All goal codes are optional, and without default. 
+
 ### States
 
 The following states are defined and included in the state transition table below.
@@ -105,6 +109,7 @@ An optional message sent by the prover to the verifier to initiate a proof prese
 {
     "@type": "https://didcomm.org/present-proof/%VER/propose-presentation",
     "@id": "<uuid-propose-presentation>",
+    "goal_code": "<goal-code>",
     "comment": "some comment",
     "formats" : [
         {
@@ -126,6 +131,7 @@ An optional message sent by the prover to the verifier to initiate a proof prese
 
 Description of fields:
 
+* `goal_code` -- optional field that indicates the goal of the message sender. 
 * `comment` -- a field that provides some human readable information about the proposed presentation.
 * `formats` -- contains an entry for each `filter~attach` array entry, including an optional value of the attachment `@id` (if attachments are present) and the verifiable presentation format and version of the attachment. Accepted values for the `format` items are provided in the per format "Attachment" sections immediately below.
 * `proposal~attach` -- an optional array of attachments that further define the presentation request being proposed. This might be used to clarify which formats or format versions are wanted.
@@ -151,6 +157,7 @@ From a verifier to a prover, the `request-presentation` message describes values
 {
     "@type": "https://didcomm.org/present-proof/%VER/request-presentation",
     "@id": "<uuid-request>",
+    "goal_code": "<goal-code>",
     "comment": "some comment",
     "will_confirm": "true",
     "formats" : [
@@ -173,6 +180,7 @@ From a verifier to a prover, the `request-presentation` message describes values
 
 Description of fields:
 
+* `goal_code` -- optional field that indicates the goal of the message sender. 
 * `comment` -- a field that provides some human readable information about this request for a presentation.
 * `will_confirm` -- an optional field that defaults to `"false"` to indicate that the verifier will or will not send a post-presentation confirmation `ack` message
 * `formats` -- contains an entry for each `request_presentations~attach` array entry, providing the the value of the attachment `@id` and the verifiable presentation request format and version of the attachment. Accepted values for the `format` items are provided in the per format [Attachment](#presentation-request-attachment-registry) registry immediately below.
@@ -193,6 +201,7 @@ This message is a response to a Presentation Request message and contains signed
 {
     "@type": "https://didcomm.org/present-proof/%VER/presentation",
     "@id": "<uuid-presentation>",
+    "goal_code": "<goal-code>",
     "comment": "some comment",
     "formats" : [
         {
@@ -216,6 +225,7 @@ This message is a response to a Presentation Request message and contains signed
 Description of fields:
 
 * `comment` -- a field that provides some human readable information about this presentation.
+* `goal_code` -- optional field that indicates the goal of the message sender. 
 * `formats` -- contains an entry for each `presentations~attach` array entry, providing the the value of the attachment `@id` and the verifiable presentation format and version of the attachment. Accepted values for the `format` items are provided in the per format [Attachment](#presentation-request-attachment-registry) registry immediately below.
 * `presentations~attach` -- an array of attachments containing the presentation in the requested format(s).
 


### PR DESCRIPTION
I think we've made a mistake by not including optional goal codes in the credential exchange protocols. I know this is a late add, so we may need to skip it for AIP 2.0 purposes.
Signed-off-by: Sam Curren <telegramsam@gmail.com>