### PR TITLE
Align RFCs with DIDComm profiles

### DIFF
--- a/features/0044-didcomm-file-and-mime-types/README.md
+++ b/features/0044-didcomm-file-and-mime-types/README.md
@@ -27,7 +27,12 @@ support a million other uses.
 
 We need to define how files and attachments can contain DIDComm messages, and what the
 semantics of processing such files will be.
+
 ## Tutorial
+
+### Media Types
+
+ Media types are based on the conventions of [RFC6838](https://tools.ietf.org/html/rfc6838). Similar to [RFC7515](https://tools.ietf.org/html/rfc7515#section-4.1.9), the `application/` prefix MAY be omitted and the recipient MUST treat media types not containing `/` as having the `application/` prefix present.
 
 ### DIDComm v1 Encrypted Envelope (*.dee)
 
@@ -162,6 +167,28 @@ There can be more than one Native Object representation for a given programming 
 
 Native Object forms are never rendered directly to files; rather, they are serialized to DIDComm Plaintext Format
 and then persisted (likely after also encrypting to DIDComm V1 Encrypted Envelope).
+
+### Negotiating Compatibility
+
+When parties want to communicate via DIDComm, a number of mechanisms must align. These include:
+
+1. The type of service endpoint used by each party
+2. The key types used for encryption and/or signing
+3. The format of the encryption and/or signing envelopes
+4. The encoding of plaintext messages
+5. The protocol used to forward and route
+6. The protocol embodied in the plaintext messages
+
+Although DIDComm allows flexibility in each of these choices, it is not expected that a given DIDComm implementation will support many permutations. Rather, we expect a few sets of choices that commonly go together. We call a set of choices that work well together a __profile__. Profiles are identified by a string that matches the conventions of IANA media types, but they express choices about plaintext, encryption, signing, and routing in a single value. The following profile identifiers are defined in this version of the RFC:
+
+### Defined Profiles
+
+- `didcomm/aip1`: The encryption envelope, signing mechanism, plaintext conventions, and routing algorithms embodied in Aries AIP 1.0, circa 2020.
+- `didcomm/aip2;env=rfc19`: The signing mechanism, plaintext conventions, and routing algorithms embodied in Aries AIP 2.0, circa 2021 -- with the old-style encryption envelope from Aries RFC 0019. This legal variant of AIP 2.0 minimizes differences with codebases that shipped AIP 1.0 support.
+- `didcomm/aip2;env=rfc587`: The signing mechanism, plaintext conventions, and routing algorithms embodied in Aries AIP 2.0, circa 2021 -- with the new-style encryption envelope from Aries RFC 0587. This legal variant of AIP 2.0 lays the foundation for DIDComm v2 support by anticipating the eventual envelope change.
+- `didcomm/v2`: The encryption envelope, signing mechanism, plaintext conventions, and routing algorithms embodied in the DIDComm messaging spec.
+
+Profiles are named in the `accept` section of a DIDComm service endpoint and in an out-of-band message. When Alice declares that she accepts `didcomm/aip2;env=rfc19`, she is making a declaration about more than her own endpoint. She is saying that all publicly visible steps in an inbound route to her will use the `didcomm/aip2;env=rfc19` profile, such that a sender only has to use `didcomm/aip2;env=rfc19` choices to get the message from Alice's outermost mediator to Alice's edge. It is up to Alice to select and configure mediators and internal routing in such a way that this is true for the sender.
 
 ### Detecting DIDComm Versions
 

--- a/features/0067-didcomm-diddoc-conventions/README.md
+++ b/features/0067-didcomm-diddoc-conventions/README.md
@@ -38,8 +38,8 @@ When a DID document wishes to express support for DID communications, the follow
     "recipientKeys" : [ "did:example:123456789abcdefghi#1" ],
     "routingKeys" : [ "did:example:123456789abcdefghi#1" ],
     "accept": [
-      "application/didcomm-encrypted+json",
-      "application/didcomm-enc-env"
+      "didcomm/aip2;env=rfc587",
+      "didcomm/aip2;env=rfc19"
     ],
     "serviceEndpoint": "https://agent.example.com/"
   }]

--- a/features/0434-outofband/README.md
+++ b/features/0434-outofband/README.md
@@ -94,8 +94,8 @@ The out-of-band protocol a single message that is sent by the *sender*.
   "goal_code": "issue-vc",
   "goal": "To issue a Faber College Graduate credential",
   "accept": [
-    "application/didcomm-encrypted+json",
-    "application/didcomm-enc-env"
+    "didcomm/aip2;env=rfc587",
+    "didcomm/aip2;env=rfc19"
   ],
   "handshake_protocols": [
     "https://didcomm.org/didexchange/1.0",

--- a/features/0587-encryption-envelope-v2/README.md
+++ b/features/0587-encryption-envelope-v2/README.md
@@ -82,7 +82,7 @@ To advertise the combination of Envelope v2 with a DIDComm v1 message, the media
 
 ## Additional AIP impacts
 
-Implementors supporting an AIP sub-target that contains this RFC (e.g., `DIDCOMMV2PREP`) MAY choose to only support Envelope v2 without support for the original envelope declared in [RFC 0019](https://github.com/hyperledger/aries-rfcs/tree/master/features/0019-encryption-envelope). In these cases, the `accept` property will not contain `application/didcomm-enc-env` media type.
+Implementors supporting an AIP sub-target that contains this RFC (e.g., `DIDCOMMV2PREP`) MAY choose to only support Envelope v2 without support for the original envelope declared in [RFC 0019](https://github.com/hyperledger/aries-rfcs/tree/master/features/0019-encryption-envelope). In these cases, the `accept` property will not contain `didcomm/aip2;env=rfc19` media type.
 
 ## Drawbacks
 


### PR DESCRIPTION
- Adds/adapts the profiles description originally from @dhh1128 in https://github.com/decentralized-identity/didcomm-messaging/pull/177 to RFC 44.
- Updates the media type examples in RFC 67, 434 and 587 to align with profiles.

Signed-off-by: Troy Ronda <troy@troyronda.com>