### PR TITLE
add `kid` and `skid` headers references section

### DIFF
--- a/features/0587-encryption-envelope-v2/README.md
+++ b/features/0587-encryption-envelope-v2/README.md
@@ -27,7 +27,7 @@ DIDComm Messaging (and this RFC) requires support for `X25519`, `P-256`, and `P-
 
 - P-256 (reference in [RFC4492](https://tools.ietf.org/search/rfc4492#appendix-A))
 - P-384 (reference in [RFC4492](https://tools.ietf.org/search/rfc4492#appendix-A))
-- P-521 (reference in [RFC4492](https://tools.ietf.org/search/rfc4492#appendix-A))
+- P-521 (optional, reference in [RFC4492](https://tools.ietf.org/search/rfc4492#appendix-A))
 - X25519 (reference in [RFC7748](https://tools.ietf.org/html/rfc7748#section-5))
 
 ### Content Encryption Algorithms
@@ -39,9 +39,72 @@ DIDComm Messaging (and this RFC) requires support for both `XC20P` and `A256GCM`
 
 ### Key Wrapping Algorithms
 
-DIDComm Messaing (and this RFC) requires support for `ECDH-1PU+A256KW`.
+DIDComm Messaging (and this RFC) requires support for `ECDH-1PU+A256KW`.
 
 - ECDH-1PU+A256KW (defined in [ECDH-1PU draft 03](https://tools.ietf.org/html/draft-madden-jose-ecdh-1pu-03#section-2.2))
+
+## Key IDs `kid` and `skid` headers references in the DID document
+
+Keys used by DIDComm envelopes MUST be sourced from the DIDs exchanged between two agents. Specifically, both sender and recipients keys MUST be retrieved from the DID document's `KeyAgreement` verification section as per the [DID Document Keys](https://identity.foundation/didcomm-messaging/spec/#did-document-keys) definition.
+
+When Alice is preparing an envelope intended for Bob, the packing process should use a key from both hers and Bob's DID document's `KeyAgreement` section.
+
+Assuming Alice has a DID Doc with the following `KeyAgreement` definition (source: [DID V1 Example 17](https://www.w3.org/TR/did-core/#example-17-key-agreement-property-containing-two-verification-methods)):
+```jsonc
+{
+  "@context": "https://www.w3.org/ns/did/v1",
+  "id": "did:example:123456789abcdefghi",
+  ...
+  "keyAgreement": [
+    // this method can be used to perform key agreement as did:...fghi
+    "did:example:123456789abcdefghi#keys-1",
+    // this method is *only* approved for key agreement usage, it will not
+    // be used for any other verification relationship, so its full description is
+    // embedded here rather than using only a reference
+    {
+      "id": "did:example:123#zC9ByQ8aJs8vrNXyDhPHHNNMSHPcaSgNpjjsBYpMMjsTdS",
+      "type": "X25519KeyAgreementKey2019", // external (property value)
+      "controller": "did:example:123",
+      "publicKeyBase58": "9hFgmPVfmBZwRvFEyniQDBkz9LmV7gDEqytWyGZLmDXE"
+    }
+  ],
+  ...
+}
+```
+
+The envelope packing process should set the `skid` header with value `did:example:123456789abcdefghi#keys-1` in the envelope's protected headers and fetch the underlying key to execute ECDH-1PU key derivation for content key wrapping.
+
+Assuming she also has Bob's DID document which happens to include the following `KeyAgreement` section:
+
+```jsonc
+{
+  "@context": "https://www.w3.org/ns/did/v1",
+  "id": "did:example:jklmnopqrstuvwxyz1",
+  ...
+  "keyAgreement": [
+    {
+      "id": "did:example:jklmnopqrstuvwxyz1#key-1",
+      "type": "X25519KeyAgreementKey2019", // external (property value)
+      "controller": "did:example:jklmnopqrstuvwxyz1",
+      "publicKeyBase58": "9hFgmPVfmBZwRvFEyniQDBkz9LmV7gDEqytWyGZLmDXE"
+    }
+  ],
+  ...
+}
+```
+
+There should be only 1 entry in the recipients of the envelope, representing Bob. The corresponding `kid` header for this recipient MUST have `did:example:jklmnopqrstuvwxyz1#key-1` as value. The packing process MUST extract the public key bytes found in `publicKeyBase58` of Bob's DID Doc `KeyAgreement[0]` to execute the ECDH-1PU key derivation for content key wrapping.
+
+When Bob receives the envelope, the unpacking process on his end MUST resolve the `skid` protected header value using Alice's DID doc's `KeyAgreement[0]` in order to extract her public key. In Alice's DID Doc example above, `KeyAgreement[0]` is a reference id, it MUST be resolved from the main `VerificationMethod[]` of Alice's DID document (not shown in the example).
+
+Once resolved, the unpacker will then execute ECDH-1PU key derivation using this key and Bob's own recipient key found in the envelope's `recipients[0]` to unwrap the content encryption key.
+
+## Protecting the `skid` header
+When the `skid` cannot be revealed in a plain-text JWE header (to avoid potentially leaking sender's key id), the `skid` MAY be encrypted for each recipient. In this case, instead of having a `skid` protected header in the envelope, each recipient MAY include an `encrypted_skid` header with a value based on the encryption of `skid` using ECDH-ES `Z` computation of the `epk` and the recipient's key as the encryption key.
+
+For applications that don't require this protection, they MAY use `skid` protected header directly without any additional recipient headers.
+
+Applications MUST use either `skid` protected header or `encrypted_skid` recipients header but not both in the same envelope.
 
 ## Anoncrypt equivalent
 


### PR DESCRIPTION
To clarify how `kid` and `skid` headers are dereferenced in DIDComm V2 envelopes, this change adds a dedicated section about them.
It also includes a section about applications requiring to protect the `skid` protected header.

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>