### PR TITLE
fix incorrect thid wording in did exchange RFC

### DIFF
--- a/features/0023-did-exchange/README.md
+++ b/features/0023-did-exchange/README.md
@@ -170,7 +170,7 @@ The _requester_ may provision a new DID according to the DID method spec. For a 
 * The `@type` attribute is a required string value that denotes that the received message is an exchange request.
 * The [`~thread`](../../concepts/0008-message-id-and-threading/README.md#thread-object) decorator MUST be included:
   * It MUST include the ID of the parent thread (`pthid`) such that the `request` can be correlated to the corresponding (implicit or explicit) `invitation`. More on correlation [below](#correlating-requests-to-invitations).
-  * It SHOULD include the `thid` property. In doing so, implementations MUST set its value to that of `@id` on the same `request` message. In other words, the values of `@id` and `~thread.thid` MUST be equal.
+  * It MAY include the `thid` property. This works according to the [`thid`](../../concepts/0008-message-id-and-threading/README.md#thread-id-thid) property in the thread decorator, meaning that if `thid` is not defined it is implicitly defined as the `@id` on the same `request` message.
 * The `label` attribute provides a suggested label for the DID being exchanged. This allows the user to tell multiple exchange requests apart. This is not a trusted attribute.
 * The `did` attribute MUST be included. It indicates the DID being exchanged.
 * The `did_doc~attach` contains the DID Doc associated with the DID.


### PR DESCRIPTION
As discussed on the WG call a few weeks ago. The did exchange protocol required the `thid` property to be equal to the message ID. This is an unnecessary restriction