### PR TITLE
Clarify text for did:key encoding - incorrect prefix per #664

### DIFF
--- a/features/0360-use-did-key/README.md
+++ b/features/0360-use-did-key/README.md
@@ -45,7 +45,7 @@ Thus, `8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K` becomes `did:key:z6MkmjY8Gn
 - Start with the original (presumably) base58 ed25519 public key
   - Since we have only a naked public key, we must assume the format
 - Base58 decode the public key to get the hex version
-- Multicodec: Prefix with the algorithm type. In this case, `ED01` as the key type is ed25519.
+- Multicodec: Prefix with the algorithm type. In this case, `0xed` is the key type of ed25519, per [multicodec table](https://github.com/multiformats/multicodec/blob/master/table.csv) (search for  `ed25519`).
 - Multibase: Base58 encode the result and prefix that with "z" to indicate base58 encoding
 - DID: Prefix that with the DID Method prefix `did:key:`
 


### PR DESCRIPTION
Clarify text for did:key encoding - fix incorrect prefix per #664
