### PR TITLE
Updated broken link

### DIFF
--- a/concepts/0003-protocols/tictactoe/README.md
+++ b/concepts/0003-protocols/tictactoe/README.md
@@ -29,7 +29,7 @@ capture 3 cells of the grid in a straight line.
 ### Name and Version
 
 This defines the `tictactoe` protocol, version 1.x, as identified by the
-following [PIURI](https://github.com/hyperledger/aries-rfcs/blob/master/concepts/0003-protocols/uris.md#piuri):
+following [PIURI](https://github.com/hyperledger/aries-rfcs/tree/master/concepts/0003-protocols#message-type-and-protocol-identifier-uris):
 
     did:sov:SLfEi9esrjzybysFxQZbfq;spec/tictactoe/1.0
 


### PR DESCRIPTION
The link no longer worked as the target document was moved.