### PR TITLE
Update Aries RFC 0025 to indicate HTTPS is preferred

### DIFF
--- a/features/0025-didcomm-transports/README.md
+++ b/features/0025-didcomm-transports/README.md
@@ -26,7 +26,7 @@ HTTP(S) is the first, and most used transport for DID Communication that has rec
 
 While it is recognized that all DIDComm messages are secured through strong encryption, making HTTPS somewhat redundant, it will likely cause issues with mobile clients because venders (Apple and Google) are limiting application access to the HTTP protocol. For example, on iOS 9 or above where [ATS])(https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity) is in effect, any URLs using HTTP must have an exception hard coded in the application prior to uploading to the iTunes Store. This makes DIDComm unreliable as the agent initiating the the request provides an endpoint for communication that the mobile client must use. If the agent provides a URL using the HTTP protocol it will likely be unusable due to low level operating system limitations.
 
-As a best practice, when HTTP is used in situations where a mobile client (iOS or Android) may be involved is is highly recommended to use the HTTPS protocol, specifically TLS 1.2 or above. 
+As a best practice, when HTTP is used in situations where a mobile client (iOS or Android) may be involved it is highly recommended to use the HTTPS protocol, specifically TLS 1.2 or above. 
 
 Other important notes on the subject of using HTTP(S) include:
 

--- a/features/0025-didcomm-transports/README.md
+++ b/features/0025-didcomm-transports/README.md
@@ -20,16 +20,21 @@ Agent Messaging is designed to be transport independent, including message encry
 
 Standardized transport methods are detailed here.
 
-### HTTPS
+### HTTP(S)
 
-HTTPS is the first, and preferred, transport for DID Communication that has received heavy attention. 
+HTTP(S) is the first, and most used transport for DID Communication that has received heavy attention. 
 
-- Messages are transported via HTTPS POST.
+While it is recognized that all DIDComm messages are secured through strong encryption, making HTTPS somewhat redundant, it will likely cause issues with mobile clients because venders (Apple and Google) are limiting application access to the HTTP protocol. For example, on iOS 9 or above where [ATS])(https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity) is in effect, any URLs using HTTP must have an exception hard coded in the application prior to uploading to the iTunes Store. This makes DIDComm unreliable as the agent initiating the the request provides an endpoint for communication that the mobile client must use. If the agent provides a URL using the HTTP protocol it will likely be unusable due to low level operating system limitations.
+
+As a best practice, when HTTP is used in situations where a mobile client (iOS or Android) may be involved is is highly recommended to use the HTTPS protocol, specifically TLS 1.2 or above. 
+
+Other important notes on the subject of using HTTP(S) include:
+
+- Messages are transported via HTTP POST.
 - The MIME Type for the POST request is `application/didcomm-envelope-enc`; see [RFC 0044: DIDComm File and MIME Types](../0044-didcomm-file-and-mime-types/README.md) for more details.
 - A received message should be responded to with a 202 Accepted status code. This indicates that the request was received, but not necessarily processed. Accepting a 200 OK status code is allowed.
 - POST requests are considered transmit only by default. No agent messages will be returned in the response. This behavior may be modified with additional signaling.
 - Using HTTPS with TLS 1.2 or greater with a forward secret cipher will provide Perfect Forward Secrecy (PFS) on the transmission leg.
-- HTTP is an option for transport but is discouraged.
 
 #### Known Implementations
 

--- a/features/0025-didcomm-transports/README.md
+++ b/features/0025-didcomm-transports/README.md
@@ -20,15 +20,16 @@ Agent Messaging is designed to be transport independent, including message encry
 
 Standardized transport methods are detailed here.
 
-### HTTP(S)
+### HTTPS
 
-HTTP(S) is the first transport for DID Communication that has received heavy attention.
+HTTPS is the first, and preferred, transport for DID Communication that has received heavy attention. 
 
-- Messages are transported via HTTP POST.
+- Messages are transported via HTTPS POST.
 - The MIME Type for the POST request is `application/didcomm-envelope-enc`; see [RFC 0044: DIDComm File and MIME Types](../0044-didcomm-file-and-mime-types/README.md) for more details.
 - A received message should be responded to with a 202 Accepted status code. This indicates that the request was received, but not necessarily processed. Accepting a 200 OK status code is allowed.
 - POST requests are considered transmit only by default. No agent messages will be returned in the response. This behavior may be modified with additional signaling.
 - Using HTTPS with TLS 1.2 or greater with a forward secret cipher will provide Perfect Forward Secrecy (PFS) on the transmission leg.
+- HTTP is an option for transport but is discouraged.
 
 #### Known Implementations
 


### PR DESCRIPTION
As per the discussion during the [Aries Mobile Summit 2021](https://wiki.hyperledger.org/display/ARIES/2021-11-16+Aries+Summit+Session) it was decided at [1:35:50](https://wiki.hyperledger.org/download/attachments/62227940/audio_only.m4a?api=v2) in the audio recording that HTTPS would be preferred over HTTP as the transport when mobile clients are involved and HTTP is the base protocol.

