### PR TITLE
Clarifications to RFC 0592 AnonCreds Attachments about unrevealed attributes and string integer encoding

### DIFF
--- a/features/0592-indy-attachments/README.md
+++ b/features/0592-indy-attachments/README.md
@@ -367,7 +367,7 @@ A gist of test value pairs can be found [here](https://gist.github.com/swcurran/
 
 #### Notes on Encoding Claims
 
-- In converting any string integer to an integer, leading 0s in the string are (by definition) not part of the integer. They leading 0's remain in the (untouched) `raw` value.
+- In converting any string integer to an integer, leading 0s in the string are (by definition) not part of the integer. The leading 0's remain in the (untouched) `raw` value.
 - The use of AnonCreds predicates, such as proving "older than 21" based on a date of birth claim without sharing the date of birth, is based on an expression involving the `encoded` value. Thus, only `raw` integers or string integers can be used in AnonCreds predicates.
 
 ## Implementations

--- a/features/0592-indy-attachments/README.md
+++ b/features/0592-indy-attachments/README.md
@@ -327,14 +327,33 @@ The identifier for this format is `hlindy/proof@v2.0`. It is a version of the (J
 }
 ```
 
+### Unrevealed Attributes
+
+AnonCreds supports a holder responding to a proof request with some of the
+requested claims included in an `unrevealed_attrs` array, as seen in the example
+above, with `attr2_referent`. Assuming the rest of the proof is valid, AnonCreds
+will indicate that a proof with unrevealed attributes has been successfully
+verified. It is the responsibility of the verifier to determine if the purpose
+of the verification has been met if some of the attributes are not revealed.
+
+There are at least a few valid use cases for this approach:
+
+- A verifier may ask for, but not require, that a prover provide all of the
+  requested attributes.
+- A verifier may ask for claims from several credentials, expecting holders to
+  only have some of the credentials. The holders respond with claims from the
+  credentials they have, and leave the other attributes unrevealed.
+  - For example, a verifier may ask for a national identity card and an resident
+    card, knowing that most holders will have one or the other.
 
 ### Encoding Claims
 
-Claims in Hyperledger Indy-based verifiable credentials are put into the credential in two forms, `raw` and `encoded`. `raw` is the actual data value, and `encoded` is the (possibly derived) integer value that is used in presentations. At this time, Indy does not take an opinion on the method used for encoding the raw value.
+Claims in AnonCreds-based verifiable credentials are put into the credential in two forms, `raw` and `encoded`. `raw` is the actual data value, and `encoded` is the (possibly derived) integer value that is used in presentations. At this time, AnonCreds does not take an opinion on the method used for encoding the raw value.
 
-Aries issuers and verifiers must agree on the encoding method so that the verifier can check that the `raw` value returned in a presentation corresponds to the proven `encoded` value. The following is the encoding algorithm that MUST be used by Issuers when creating credentials and SHOULD be verified by Verifiers receiving presentations:
+AnonCreds issuers and verifiers must agree on the encoding method so that the verifier can check that the `raw` value returned in a presentation corresponds to the proven `encoded` value. The following is the encoding algorithm that MUST be used by Issuers when creating credentials and SHOULD be verified by Verifiers receiving presentations:
 
 - keep any 32-bit integer as is
+- convert any string integer (e.g. `"1234"`) to be a 32-bit integer (e.g. `1234`)
 - for data of any other type:
   - convert to string (use string "None" for null)
   - encode via utf-8 to bytes
@@ -345,6 +364,11 @@ Aries issuers and verifiers must agree on the encoding method so that the verifi
 An example implementation in Python can be found [here](https://github.com/hyperledger/aries-cloudagent-python/blob/0000f924a50b6ac5e6342bff90e64864672ee935/aries_cloudagent/messaging/util.py#L106).
 
 A gist of test value pairs can be found [here](https://gist.github.com/swcurran/78e5a9e8d11236f003f6a6263c6619a6).
+
+#### Notes on Encoding Claims
+
+- In converting any string integer to an integer, leading 0s in the string are (by definition) not part of the integer. They leading 0's remain in the (untouched) `raw` value.
+- The use of AnonCreds predicates, such as proving "older than 21" based on a date of birth claim without sharing the date of birth, is based on an expression involving the `encoded` value. Thus, only `raw` integers or string integers can be used in AnonCreds predicates.
 
 ## Implementations
 


### PR DESCRIPTION
As discussed in the [Aries WG Meeting, August 17, 2022](https://wiki.hyperledger.org/display/ARIES/2022-08-17+Aries+Working+Group+Call), this PR adds clarifications about the processing of unrevealed attributes in a proof request (verified, and the verifier business logic must decide if not revealing all claims is sufficient in a given use case), and the handling of strings of integers when encoding claims (convert them to integers).