### PR TITLE
feat: add anoncreds attachments rfc

### DIFF
--- a/features/0453-issue-credential-v2/README.md
+++ b/features/0453-issue-credential-v2/README.md
@@ -198,7 +198,8 @@ Credential Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
 DIF Credential Manifest | `dif/credential-manifest@v1.0` | [`propose-credential` attachment format](../0511-dif-cred-manifest-attach/README.md#propose-credential-attachment-format) | 
 Linked Data Proof VC Detail  | `aries/ld-proof-vc-detail@v1.0` | [`ld-proof-vc-detail` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-detail-attachment-format) |
-Hyperledger Indy Credential Abstract | `hlindy/cred-filter@v2.0` | [`cred filter` format](../0592-indy-attachments/README.md#cred-filter-format)|
+Hyperledger Indy Credential Filter | `hlindy/cred-filter@v2.0` | [`cred filter` format](../0592-indy-attachments/README.md#cred-filter-format)|
+Hyperledger AnonCreds Credential Filter | `anoncreds/credential-filter@v1.0` | [`Credential Filter` format](../0771-anoncreds-attachments/README.md#credential-filter-format)|
 
 #### Offer Credential
 
@@ -271,6 +272,7 @@ Credential Format | Format Value | Link to Attachment Format | Comment |
 DIF Credential Manifest | `dif/credential-manifest@v1.0` | [`offer-credential` attachment format](../0511-dif-cred-manifest-attach/README.md#offer-credential-attachment-format) | 
 Hyperledger Indy Credential Abstract | `hlindy/cred-abstract@v2.0` | [`cred abstract` format](../0592-indy-attachments/README.md#cred-abstract-format)|
 Linked Data Proof VC Detail  | `aries/ld-proof-vc-detail@v1.0` | [`ld-proof-vc-detail` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-detail-attachment-format) |
+Hyperledger AnonCreds Credential Offer | `anoncreds/credential-offer@v1.0` | [`Credential Offer` format](../0771-anoncreds-attachments/README.md#credential-offer-format)|
 
 #### Request Credential
 
@@ -341,6 +343,7 @@ Credential Format | Format Value | Link to Attachment Format | Comment |
 DIF Credential Manifest | `dif/credential-manifest@v1.0` | [`request-credential` attachment format](../0511-dif-cred-manifest-attach/README.md#request-credential-attachment-format) | 
 Hyperledger Indy Credential Request | `hlindy/cred-req@v2.0` | [`cred request` format](../0592-indy-attachments/README.md#cred-request-format)|
 Linked Data Proof VC Detail  | `aries/ld-proof-vc-detail@v1.0` | [`ld-proof-vc-detail` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-detail-attachment-format) |
+Hyperledger AnonCreds Credential Request | `anoncreds/credential-request@v1.0` | [`Credential Request` format](../0771-anoncreds-attachments/README.md#credential-request-format)|
 
 #### Issue Credential
 
@@ -411,6 +414,7 @@ Credential Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
 Linked Data Proof VC  | `aries/ld-proof-vc@v1.0` | [`ld-proof-vc` attachment format](../0593-json-ld-cred-attach/README.md#ld-proof-vc-attachment-format) |
 Hyperledger Indy Credential | `hlindy/cred@v2.0` | [credential format](../0592-indy-attachments/README.md#credential-format)|
+Hyperledger AnonCreds Credential| `anoncreds/credential@v1.0` | [`Credential` format](../0771-anoncreds-attachments/README.md#credential-format)|
 
 #### Adopted Problem Report
 

--- a/features/0454-present-proof-v2/README.md
+++ b/features/0454-present-proof-v2/README.md
@@ -158,8 +158,9 @@ Negotiation prior to the delivery of the presentation can be done using the `pro
 
 Presentation Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
-Hyperledger Indy Proof Req| hlindy/proof-req@v2.0 | [proof request format](../0592-indy-attachments/README.md#proof-request-format) | Used to propose as well as request proofs.
+Hyperledger Indy Proof Req | `hlindy/proof-req@v2.0` | [proof request format](../0592-indy-attachments/README.md#proof-request-format) | Used to propose as well as request proofs.
 DIF Presentation Exchange | `dif/presentation-exchange/definitions@v1.0` | [`propose-presentation` attachment format](../0510-dif-pres-exch-attach/README.md#propose-presentation-attachment-format) | 
+Hyperledger AnonCreds Proof Request | `anoncreds/proof-request@v1.0` | [`Proof Request` format](../0771-anoncreds-attachments/README.md#proof-request-format) | Used to propose as well as request proofs.
 
 ### Request Presentation
 
@@ -209,8 +210,9 @@ from both employment and education verifiable credentials held by the Prover.
 
 Presentation Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
-Hyperledger Indy Proof Req| hlindy/proof-req@v2.0 | [proof request format](../0592-indy-attachments/README.md#proof-request-format) | Used to propose as well as request proofs.
+Hyperledger Indy Proof Req| `hlindy/proof-req@v2.0` | [proof request format](../0592-indy-attachments/README.md#proof-request-format) | Used to propose as well as request proofs.
 DIF Presentation Exchange | `dif/presentation-exchange/definitions@v1.0` | [`propose-presentation` attachment format](../0510-dif-pres-exch-attach/README.md#request-presentation-attachment-format) | 
+Hyperledger AnonCreds Proof Request | `anoncreds/proof-request@v1.0` | [`Proof Request` format](../0771-anoncreds-attachments/README.md#proof-request-format) | Used to propose as well as request proofs.
 
 ### Presentation
 
@@ -277,6 +279,7 @@ Presentation Format | Format Value | Link to Attachment Format | Comment |
 --- | --- | --- | --- | 
 Hyperledger Indy Proof | hlindy/proof@v2.0 | [proof format](../0592-indy-attachments/README.md#proof-format) |
 DIF Presentation Exchange | `dif/presentation-exchange/submission@v1.0` | [`propose-presentation` attachment format](../0510-dif-pres-exch-attach/README.md#presentation-attachment-format) | 
+Hyperledger AnonCreds Proof | `anoncreds/proof@v1.0` | [`Proof` format](../0771-anoncreds-attachments/README.md#proof-format) |
 
 ### Ack Presentation
 

--- a/features/0771-anoncreds-attachments/README.md
+++ b/features/0771-anoncreds-attachments/README.md
@@ -1,0 +1,341 @@
+# Aries RFC 0771: AnonCreds Attachment Formats for Requesting and Presenting Credentials
+
+- Authors: [Timo Glastra](mailto:timo@animo.id), [Daniel Hardman](mailto:daniel.hardman@gmail.com)
+- Status: [PROPOSED](/README.md#proposed)
+- Since: 2023-02-24
+- Status Note: Formalizes the AnonCreds attachments for issuing credentials and presenting proofs over DIDComm.
+- Supersedes: Hyperledger Indy specific AnonCreds attachment formats documented in [Aries RFC 0592](../0592-indy-attachments/README.md).
+- Start Date: 2023-02-24
+- Tags: [feature](/tags.md#feature), [protocol](/tags.md#protocol), [credentials](/tags.md#credentials), [test-anomaly](/tags.md#test-anomaly)
+
+## Summary
+
+This RFC registers attachment formats used with [Hyperledger AnonCreds](https://hyperledger.github.io/anoncreds-spec/) ZKP-oriented credentials in the [Issue Credential Protocol 2.0](../0453-issue-credential-v2/README.md) and [Present Proof Protocol 2.0](../0454-present-proof-v2/README.md). If not specified otherwise, this follows the rules as defined in the [AnonCreds Specification](https://hyperledger.github.io/anoncreds-spec/).
+
+## Motivation
+
+Allows AnonCreds credentials to be used with credential-related protocols that take pluggable formats as payloads.
+
+## Reference
+
+### Credential Filter format
+
+The potential holder uses this format to propose criteria for a potential credential for the issuer to offer. The format defined here is not part of the AnonCreds spec, but is a Hyperledger Aries-specific message.
+
+The identifier for this format is `anoncreds/credential-filter@v1.0`. The data structure allows specifying zero or more criteria from the following structure:
+
+```jsonc
+{
+  "schema_issuer_id": "<schema_issuer_id>",
+  "schema_name": "<schema_name>",
+  "schema_version": "<schema_version>",
+  "schema_id": "<schema_identifier>",
+  "issuer_id": "<issuer_id>",
+  "cred_def_id": "<credential_definition_identifier>"
+}
+```
+
+The potential holder may not know, and need not specify, all of these criteria. For example, the holder might only know the schema name and the (credential) issuer id. Recall that the potential holder may specify target attribute values and MIME types in the [credential preview](../0453-issue-credential-v2/README.md#preview-credential).
+
+For example, the JSON structure might look like this:
+
+```json
+{
+  "schema_issuer_id": "did:sov:4RW6QK2HZhHxa2tg7t1jqt",
+  "schema_name": "bcgov-mines-act-permit.bcgov-mines-permitting",
+  "issuer_id": "did:sov:4RW6QK2HZhHxa2tg7t1jqt"
+}
+```
+
+A complete [`propose-credential` message from the Issue Credential protocol 2.0](../0453-issue-credential-v2/README.md#propose-credential) embeds this format as an attachment in the `filters~attach` array:
+
+```json
+{
+  "@id": "<uuid of propose message>",
+  "@type": "https://didcomm.org/issue-credential/%VER/propose-credential",
+  "comment": "<some comment>",
+  "formats": [
+    {
+      "attach_id": "<attach@id value>",
+      "format": "anoncreds/cred-filter@v1.0"
+    }
+  ],
+  "filters~attach": [
+    {
+      "@id": "<attach@id value>",
+      "mime-type": "application/json",
+      "data": {
+        "base64": "ewogICAgInNjaGVtYV9pc3N1ZXJfZGlkIjogImRpZDpzb3Y... (clipped)... LMkhaaEh4YTJ0Zzd0MWpxdCIKfQ=="
+      }
+    }
+  ]
+}
+```
+
+### Credential Offer format
+
+This format is used to clarify the structure and semantics (but not the concrete data values) of a potential credential, in offers sent from issuer to potential holder.
+
+The identifier for this format is `anoncreds/credential-offer@v1.0`. It must follow the [structure of a Credential Offer](https://hyperledger.github.io/anoncreds-spec/#credential-offer) as defined in the AnonCreds specification.
+
+The JSON structure might look like this:
+
+```json
+{
+    "schema_id": "4RW6QK2HZhHxa2tg7t1jqt:2:bcgov-mines-act-permit.bcgov-mines-permitting:0.2.0",
+    "cred_def_id": "4RW6QK2HZhHxa2tg7t1jqt:3:CL:58160:default",
+    "nonce": "57a62300-fbe2-4f08-ace0-6c329c5210e1",
+    "key_correctness_proof" : <key_correctness_proof>
+}
+```
+
+A complete [`offer-credential` message from the Issue Credential protocol 2.0](../0453-issue-credential-v2/README.md#offer-credential) embeds this format as an attachment in the `offers~attach` array:
+
+```json
+{
+    "@type": "https://didcomm.org/issue-credential/%VER/offer-credential",
+    "@id": "<uuid of offer message>",
+    "replacement_id": "<issuer unique id>",
+    "comment": "<some comment>",
+    "credential_preview": <json-ld object>,
+    "formats" : [
+        {
+            "attach_id" : "<attach@id value>",
+            "format": "anoncreds/credential-offer@v1.0"
+        }
+    ],
+    "offers~attach": [
+        {
+            "@id": "<attach@id value>",
+            "mime-type": "application/json",
+            "data": {
+                "base64": "ewogICAgInNjaGVtYV9pZCI6ICI0Ulc2UUsySFpoS... (clipped)... jb3JyZWN0bmVzc19wcm9vZj4KfQ=="
+            }
+        }
+    ]
+}
+```
+
+### cred request format
+
+This format is used to formally request a credential. It differs from the Credential Offer above in that it contains a cryptographic commitment to a link secret; an issuer can therefore use it to bind a concrete instance of an issued credential to the appropriate holder. (In contrast, the credential offer describes the schema and cred definition, but not enough information to actually issue to a specific holder.)
+
+The identifier for this format is `anoncreds/cred-request@v1.0`. It must follow the [structure of a Credential Request](https://hyperledger.github.io/anoncreds-spec/#credential-request) as defined in the AnonCreds specification.
+
+The JSON structure might look like this:
+
+```jsonc
+{
+    "entropy" : "e7bc23ad-1ac8-4dbc-92dd-292ec80c7b77",
+    "cred_def_id" : "4RW6QK2HZhHxa2tg7t1jqt:3:CL:58160:default",
+    // Fields below can depend on Cred Def type
+    "blinded_ms" : <blinded_master_secret>,
+    "blinded_ms_correctness_proof" : <blinded_ms_correctness_proof>,
+    "nonce": "fbe22300-57a6-4f08-ace0-9c5210e16c32"
+}
+```
+
+A complete [`request-credential` message from the Issue Credential protocol 2.0](../0453-issue-credential-v2/README.md#request-credential) embeds this format as an attachment in the `requests~attach` array:
+
+```json
+{
+  "@id": "cf3a9301-6d4a-430f-ae02-b4a79ddc9706",
+  "@type": "https://didcomm.org/issue-credential/%VER/request-credential",
+  "comment": "<some comment>",
+  "formats": [
+    {
+      "attach_id": "7cd11894-838a-45c0-a9ec-13e2d9d125a1",
+      "format": "anoncreds/credential-request@v1.0"
+    }
+  ],
+  "requests~attach": [
+    {
+      "@id": "7cd11894-838a-45c0-a9ec-13e2d9d125a1",
+      "mime-type": "application/json",
+      "data": {
+        "base64": "ewogICAgInByb3Zlcl9kaWQiIDogImRpZDpzb3Y6YWJjeHl.. (clipped)... DAtNTdhNi00ZjA4LWFjZTAtOWM1MjEwZTE2YzMyIgp9"
+      }
+    }
+  ]
+}
+```
+
+### Credential format
+
+A concrete, issued AnonCreds credential may be transmitted over many protocols, but is specifically expected as the final message in [Issuance Protocol 2.0](../0453-issue-credential-v2/README.md). The identifier for this format is `anoncreds/credential@v1.0`.
+
+This is a credential that's designed to be _held_ but not _shared directly_. It is stored in the holder's wallet and used to [derive a novel ZKP](https://youtu.be/bnbNtjsKb4k?t=1280) or [W3C-compatible verifiable presentation](https://docs.google.com/document/d/1ntLZGMah8iJ_TWQdbrNNW9OVwPbIWkkCMiid7Be1PrA/edit#heading=h.vw0mboesl528) just in time for each sharing of credential material.
+
+The encoded values of the credential MUST follow the encoding algorithm as described in [Encoding Attribute Data](https://hyperledger.github.io/anoncreds-spec/#encoding-attribute-data). It must follow the [structure of a Credential](https://hyperledger.github.io/anoncreds-spec/#constructing-a-credential) as defined in the AnonCreds specification.
+
+The JSON structure might look like this:
+
+```jsonc
+{
+    "schema_id": "4RW6QK2HZhHxa2tg7t1jqt:2:bcgov-mines-act-permit.bcgov-mines-permitting:0.2.0",
+    "cred_def_id": "4RW6QK2HZhHxa2tg7t1jqt:3:CL:58160:default",
+    "rev_reg_id", "EyN78DDGHyok8qw6W96UBY:4:EyN78DDGHyok8qw6W96UBY:3:CL:56389:CardossierOrgPerson:CL_ACCUM:1-1000",
+    "values": {
+        "attr1" : {"raw": "value1", "encoded": "value1_as_int" },
+        "attr2" : {"raw": "value2", "encoded": "value2_as_int" }
+    },
+    // Fields below can depend on Cred Def type
+    "signature": <signature>,
+    "signature_correctness_proof": <signature_correctness_proof>
+    "rev_reg": <revocation registry state>
+    "witness": <witness>
+}
+```
+
+An exhaustive description of the format is out of scope here; it is more completely documented in the [AnonCreds Specification](https://hyperledger.github.io/anoncreds-spec).
+
+### Proof Request format
+
+This format is used to formally request a verifiable presenation (proof) derived from an AnonCreds-style ZKP-oriented credential.
+
+The format can also be used to _propose_ a presentation, in this case the `nonce` field MUST NOT be provided. The `nonce` field is required when the proof request is used to request a proof.
+
+The identifier for this format is `anoncreds/proof-request@v1.0`. It must follow the [structure of a Proof](https://hyperledger.github.io/anoncreds-spec/#create-presentation-request) as defined in the AnonCreds specification.
+
+Here is a sample proof request that embodies the following: "Using a government-issued ID, disclose the credential holder’s name and height, hide the credential holder’s sex, get them to self-attest their phone number, and prove that their age is at least 18":
+
+```jsonc
+{
+    "nonce": "2934823091873049823740198370q23984710239847",
+    "name":"proof_req_1",
+    "version":"0.1",
+    "requested_attributes":{
+        "attr1_referent": {"name":"sex"},
+        "attr2_referent": {"name":"phone"},
+        "attr3_referent": {"names": ["name", "height"], "restrictions": <restrictions specifying government-issued ID>}
+    },
+    "requested_predicates":{
+        "predicate1_referent":{"name":"age","p_type":">=","p_value":18}
+    }
+}
+```
+
+### Proof format
+
+This is the format of an AnonCreds-style ZKP. The raw values encoded in the presentation MUST be verified against the encoded values using the encoding algorithm as described in [Encoding Attribute Data](https://hyperledger.github.io/anoncreds-spec/#encoding-attribute-data)
+
+The identifier for this format is `anoncreds/proof@v1.0`. It must follow the [structure of a Presentation](https://hyperledger.github.io/anoncreds-spec/#generate-presentation) as defined in the AnonCreds specification.
+
+A proof that responds to the [previous proof request sample](#proof-request-format) looks like this:
+
+```jsonc
+{
+  "proof":{
+    "proofs":[
+      {
+        "primary_proof":{
+          "eq_proof":{
+            "revealed_attrs":{
+              "height":"175",
+              "name":"1139481716457488690172217916278103335"
+            },
+            "a_prime":"5817705...096889",
+            "e":"1270938...756380",
+            "v":"1138...39984052",
+            "m":{
+              "master_secret":"375275...0939395",
+              "sex":"3511483...897083518",
+              "age":"13430...63372249"
+            },
+            "m2":"1444497...2278453"
+          },
+          "ge_proofs":[
+            {
+              "u":{
+                "1":"152500...3999140",
+                "2":"147748...2005753",
+                "0":"8806...77968",
+                "3":"10403...8538260"
+              },
+              "r":{
+                "2":"15706...781609",
+                "3":"343...4378642",
+                "0":"59003...702140",
+                "DELTA":"9607...28201020",
+                "1":"180097...96766"
+              },
+              "mj":"134300...249",
+              "alpha":"827896...52261",
+              "t":{
+                "2":"7132...47794",
+                "3":"38051...27372",
+                "DELTA":"68025...508719",
+                "1":"32924...41082",
+                "0":"74906...07857"
+              },
+              "predicate":{
+                "attr_name":"age",
+                "p_type":"GE",
+                "value":18
+              }
+            }
+          ]
+        },
+        "non_revoc_proof":null
+      }
+    ],
+    "aggregated_proof":{
+      "c_hash":"108743...92564",
+      "c_list":[ 6 arrays of 257 numbers between 0 and 255]
+    }
+  },
+  "requested_proof":{
+    "revealed_attrs":{
+      "attr1_referent":{
+        "sub_proof_index":0,
+        "raw":"Alex",
+        "encoded":"1139481716457488690172217916278103335"
+      }
+    },
+    "revealed_attr_groups":{
+      "attr4_referent":{
+        "sub_proof_index":0,
+        "values":{
+          "name":{
+            "raw":"Alex",
+            "encoded":"1139481716457488690172217916278103335"
+          },
+          "height":{
+            "raw":"175",
+            "encoded":"175"
+          }
+        }
+      }
+    },
+    "self_attested_attrs":{
+      "attr3_referent":"8-800-300"
+    },
+    "unrevealed_attrs":{
+      "attr2_referent":{
+        "sub_proof_index":0
+      }
+    },
+    "predicates":{
+      "predicate1_referent":{
+        "sub_proof_index":0
+      }
+    }
+  },
+  "identifiers":[
+    {
+      "schema_id":"NcYxiDXkpYi6ov5FcYDi1e:2:gvt:1.0",
+      "cred_def_id":"NcYxi...cYDi1e:2:gvt:1.0:TAG_1",
+      "rev_reg_id":null,
+      "timestamp":null
+    }
+  ]
+}
+```
+
+## Implementations
+
+The following lists the implementations (if any) of this RFC. Please do a pull request to add your implementation. If the implementation is open source, include a link to the repo or to the implementation within the repo. Please be consistent in the "Name" field so that a mechanical processing of the RFCs can generate a list of all RFCs supported by an Aries implementation.
+
+| Name / Link | Implementation Notes |
+| ----------- | -------------------- |
+|             |

--- a/index.md
+++ b/index.md
@@ -121,6 +121,7 @@
 * [0728: Device Binding Attachments](features/0728-device-binding-attachments/README.md) (2022-04-07 &mdash; [`feature`](/tags.md#feature))
 * [0734: Push Notifications fcm Protocol 1.0](features/0734-push-notifications-fcm/README.md) (2022-05-12 &mdash; [`feature`](/tags.md#feature) [`protocol`](/tags.md#protocol))
 * [0757: Push Notification](concepts/0757-push-notification/README.md) (2022-11-02  &mdash; [`concept`](/tags.md#concept))
+* [0771: AnonCreds Attachment Formats for Requesting and Presenting Credentials](features/0771-anoncreds-attachments/README.md) (2023-02-24 &mdash; [`feature`](/tags.md#feature) [`protocol`](/tags.md#protocol) [`credentials`](/tags.md#credentials) [`test-anomaly`](/tags.md#test-anomaly))
 
 ## [RETIRED](README.md#retired)
 * [0234: Signature Decorator](features/0234-signature-decorator/README.md) (2020-10-14, [3 impls](features/0234-signature-decorator/README.md#implementations) &mdash; [`feature`](/tags.md#feature) [`decorator`](/tags.md#decorator))


### PR DESCRIPTION
Adds an RFC for the new AnonCreds credential format. The RFC is mostly based on RFC 0592, with some changes:
- Some names have been changed to align more with the spec.
- Remove references to indy-sdk code
- Remove encoding algorithm and instead point to the specification
- Update the proof request to not allow a `nonce` when using for a proposal, while requiring it for a request (see https://github.com/hyperledger/aries-rfcs/issues/766).

@dhh1128 I've included you as an author as the RFC is mostly based on RFC 0592 which you wrote. Let me know if you'd like your name removed.

Fixes #761 
