### PR TITLE
Revise the well known goal codes aries.rel and aries.rel.build

### DIFF
--- a/concepts/0519-goal-codes/README.md
+++ b/concepts/0519-goal-codes/README.md
@@ -126,17 +126,35 @@ aries | Hyperledger Aries Community | TBD
 The following goal codes are defined here because they already have demonstrated utility, based on early SSI work in Aries and elsewhere.
 
 ##### `aries.vc`
+
 Participate in some form of VC-based interaction. 
+
 ##### `aries.vc.issue`
+
 Issue a verifiable credential. 
+
 ##### `aries.vc.verify`
+
 Verify or validate VC-based assertions.
+
 ##### `aries.vc.revoke`
+
 Revoke a VC.
+
 ##### `aries.rel`
-Create, maintain, or end something that humans would consider a relationship. This should not to be confused with building a DIDComm channel. (Building a DIDComm channel is a low-level procedure, not a high-level goal.)
+
+Create, maintain, or end something that humans would consider a relationship.
+This may be accomplished by establishing, updating or deleting a DIDComm
+messaging connection that provides a secure communication channel for the
+relationship. The DIDComm connection itself is not the relationship, but would
+be used to carry out interactions between the parties to facilitate the
+relationship.
+
 ##### `aries.rel.build`
-Create a relationship. Carries the meaning implied today by a LinkedIn invitation to connect or a Facebook "Friend" request.
+
+Create a relationship. Carries the meaning implied today by a LinkedIn
+invitation to connect or a Facebook "Friend" request. Could be as limited
+as creating a DIDComm Connection.
 
 ## Implementations
 


### PR DESCRIPTION
Updates the definition of where to use "aries.rel" and "aries.rel.build to remove the "can't be used to establish a DIDComm connection". We see no reason for that limitation. 

We have come across the need for a goal code that we can use when doing nothing more than making a DIDComm connection between agents controlled by humans. Scenarios:

- Two Mobile Wallet apps, with an invitation from one for the other in order to establish a connection to be used for a variety of purposes - messaging, issuance, and verification.
- An enterprise agent sends an invitation to a Mobile Agent (via a QR code) to establish a connection for a variety of purposes - messaging, issuance, and verification.
