### PR TITLE
Add clarification to thread RFC about handling an empty thread decorator

### DIFF
--- a/concepts/0008-message-id-and-threading/README.md
+++ b/concepts/0008-message-id-and-threading/README.md
@@ -71,6 +71,10 @@ Message threading will be implemented as a [decorator](../0011-decorators/README
 The `~thread` decorator is generally required on any type of response, since
 this is what connects it with the original request.
 
+While not recommended, the initial message of a new protocol instance MAY have an
+empty (`{}`) `~thread` item. Aries agents receiving a message with an empty
+`~thread` item MUST gracefully handle such a message.
+
 #### Thread object
 
 A thread object has the following fields discussed below:


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>

See issue [#875 in Aries VCX](https://github.com/hyperledger/aries-vcx/issues/875).  This PR clarifies that while it is not recommended, an Aries agent MAY put an empty `~thread: {}` item in the first message of a protocol instance, and a recipient Aries agent MUST be able to handle that.
