### PR TITLE
Fix typo in Aries for OCA RFC - missing _text on credential_help_text attribute

### DIFF
--- a/features/0755-oca-for-aries/README.md
+++ b/features/0755-oca-for-aries/README.md
@@ -190,7 +190,7 @@ name/value pairs, specific to the OCA for Aries use case:
   - `issuer` - the name of the issuer of the credential.
   - `issuer_description` - a description for the issuer of the credential.
   - `issuer_url` - a URL for the issuer of the credential.
-  - `credential_help` - help text about the credential
+  - `credential_help_text` - help text about the credential
   - `credential_support_url` - a URL for a service providing support in the use of the credential.
 - The **[Unit Overlay]**
   allows the issuer to declare the units of measurement for the attributes in
@@ -417,7 +417,7 @@ as the tooling evolves.
       - "issuer"
       - "issuer_description"
       - "issuer_url"
-      - "credential_help"
+      - "credential_help_text"
       - "credential_support_url"
       - "watermark"
         - The "watermark" is used to mark non-production credentials, as described in the ["non-production watermark" section of RFC0756 OCA for Aries Style Guide](../0756-oca-for-aries-style-guide#non-production-watermark)


### PR DESCRIPTION
Fixes typo found in the Aries RFC. The other supporting documents such as the Excel file for building an OCA file, and the example OCA Bundles have the attribute name, `credential_help_text`, as does the JavaScript implementation of OCA published from the [Aries Bifold](https://github.com/hyperledger/aries-mobile-agent-react-native) repository. In my checking, all OCA Bundles that have been created that I could find are including the `_text`. 

This PR corrects the text in the actual RFC.

Wish we had caught this earlier...
