### PR TITLE
fix: deployed favicon/logo 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,8 @@ repo_url: https://github.com/hyperledger/aries-rfcs
 theme:
   name: material
   # custom_dir: overrides
-  logo: /collateral/Hyperledger_Aries_Logo_White.png
-  favicon: /collateral/favicon.ico
+  logo: https://raw.githubusercontent.com/hyperledger/aries-rfcs/main/collateral/Hyperledger_Aries_Logo_White.png
+  favicon: https://raw.githubusercontent.com/hyperledger/aries-rfcs/main/collateral/favicon.ico
   icon:
     repo: fontawesome/brands/github
   palette:


### PR DESCRIPTION
Fixes favicon/logo from #837. For some reason using the relative path works fine locally but not once deployed. I'll see if I can get to some of the actual items on the list too given I can now run locally.

cc: @swcurran 